### PR TITLE
ci: add CI workflow for PRs and main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    name: Check & Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install protobuf compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Build
+        run: cargo build --workspace
+
+      - name: Run tests
+        run: cargo test --workspace

--- a/liboxia-ffi/src/lib.rs
+++ b/liboxia-ffi/src/lib.rs
@@ -224,10 +224,7 @@ pub extern "C" fn oxia_put_result_free(result: *mut COxiaPutResult) {
 }
 
 #[no_mangle]
-pub extern "C" fn oxia_client_delete(
-    client: *const OxiaClient,
-    key: *const c_char,
-) -> COxiaError {
+pub extern "C" fn oxia_client_delete(client: *const OxiaClient, key: *const c_char) -> COxiaError {
     let rt = get_runtime();
     let key = unsafe { CStr::from_ptr(key).to_str().unwrap().to_string() };
     let result = rt.block_on(async {
@@ -300,8 +297,9 @@ pub extern "C" fn oxia_list_result_free(result: *mut COxiaListResult) {
     if !result.is_null() {
         let box_result = unsafe { Box::from_raw(result) };
         if !box_result.keys.is_null() {
-            let keys =
-                unsafe { Vec::from_raw_parts(box_result.keys, box_result.keys_len, box_result.keys_len) };
+            let keys = unsafe {
+                Vec::from_raw_parts(box_result.keys, box_result.keys_len, box_result.keys_len)
+            };
             for key in keys {
                 if !key.is_null() {
                     unsafe {

--- a/liboxia-ffi/src/lib.rs
+++ b/liboxia-ffi/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
 use std::ffi::{c_char, CStr, CString};
 use std::slice;
 use std::sync::OnceLock;

--- a/liboxia-native/examples/streaming_sequence.rs
+++ b/liboxia-native/examples/streaming_sequence.rs
@@ -37,10 +37,7 @@ async fn main() {
     let listener = tokio::spawn(async move {
         let mut count = 0;
         while let Some(highest_key) = sequence_rx.recv().await {
-            info!(
-                "Sequence update: highest_sequence_key={:?}",
-                highest_key
-            );
+            info!("Sequence update: highest_sequence_key={:?}", highest_key);
             count += 1;
             if count >= 5 {
                 break;
@@ -65,10 +62,7 @@ async fn main() {
             )
             .await
             .unwrap();
-        info!(
-            "Put sequence event {}: generated key={:?}",
-            i, result.key
-        );
+        info!("Put sequence event {}: generated key={:?}", i, result.key);
     }
 
     // Wait for listener to process updates (with timeout)

--- a/liboxia-native/src/batch.rs
+++ b/liboxia-native/src/batch.rs
@@ -218,10 +218,8 @@ impl WriteBatch {
         }
         match self.write_stream_manager.write(write_request).await {
             Ok(response) => {
-                for (mut operation, put_response) in self
-                    .put_inflight
-                    .drain(..)
-                    .zip(response.puts.into_iter())
+                for (mut operation, put_response) in
+                    self.put_inflight.drain(..).zip(response.puts.into_iter())
                 {
                     operation.complete(put_response);
                 }

--- a/liboxia-native/src/batch.rs
+++ b/liboxia-native/src/batch.rs
@@ -76,11 +76,8 @@ impl ReadBatch {
         true
     }
     fn add(&mut self, operation: Operation) {
-        match operation {
-            Operation::Get(get) => {
-                self.get_inflight.push(get);
-            }
-            _ => {}
+        if let Operation::Get(get) = operation {
+            self.get_inflight.push(get);
         }
     }
 
@@ -105,9 +102,8 @@ impl ReadBatch {
                 }
                 match provider.read(request).await {
                     Ok(response) => {
-                        let result = self.receive_all(response).await;
-                        if result.is_err() {
-                            self.failure_inflight(result.unwrap_err())
+                        if let Err(err) = self.receive_all(response).await {
+                            self.failure_inflight(err)
                         }
                     }
                     Err(err) => self.failure_inflight(UnexpectedStatus(err.to_string())),
@@ -129,11 +125,9 @@ impl ReadBatch {
                 // stream is closed
                 break;
             }
-            let next_result = next.unwrap();
-            if next_result.is_err() {
-                return Err(UnexpectedStatus(next_result.unwrap_err().to_string()));
-            }
-            let read_response = next_result?;
+            let read_response = next
+                .unwrap()
+                .map_err(|err| UnexpectedStatus(err.to_string()))?;
             for get_response in read_response.gets {
                 let next_inflight = inflight_iter.next();
                 if next_inflight.is_none() {

--- a/liboxia-native/src/batch_manager.rs
+++ b/liboxia-native/src/batch_manager.rs
@@ -96,6 +96,7 @@ impl BatchManager {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn start_batcher(
     context: CancellationToken,
     mut rx: UnboundedReceiver<Operation>,

--- a/liboxia-native/src/client.rs
+++ b/liboxia-native/src/client.rs
@@ -268,7 +268,7 @@ pub(crate) struct Inner {
 }
 
 /// The Oxia client for interacting with the Oxia distributed key-value store.
-/// 
+///
 /// This is the main client struct that users should use to interact with Oxia.
 /// It can be easily stored in other structs and cloned efficiently.
 #[derive(Clone)]
@@ -579,8 +579,7 @@ impl Client for OxiaClient {
                     batch_manager.clone(),
                 ));
             }
-            let all_results: Vec<Result<GetResult, OxiaError>> =
-                join_set.join_all().await;
+            let all_results: Vec<Result<GetResult, OxiaError>> = join_set.join_all().await;
             // Separate successes and errors
             let mut results: Vec<GetResult> = Vec::new();
             let mut last_error: Option<OxiaError> = None;
@@ -665,8 +664,13 @@ impl Client for OxiaClient {
         min_key_inclusive: String,
         max_key_exclusive: String,
     ) -> Result<RangeScanResult, OxiaError> {
-        <Self as Client>::range_scan_with_options(self, min_key_inclusive, max_key_exclusive, vec![])
-            .await
+        <Self as Client>::range_scan_with_options(
+            self,
+            min_key_inclusive,
+            max_key_exclusive,
+            vec![],
+        )
+        .await
     }
 
     async fn range_scan_with_options(
@@ -718,8 +722,13 @@ impl Client for OxiaClient {
         min_key_inclusive: String,
         max_key_exclusive: String,
     ) -> Result<(), OxiaError> {
-        <Self as Client>::delete_range_with_options(self, min_key_inclusive, max_key_exclusive, vec![])
-            .await
+        <Self as Client>::delete_range_with_options(
+            self,
+            min_key_inclusive,
+            max_key_exclusive,
+            vec![],
+        )
+        .await
     }
 
     async fn delete_range_with_options(

--- a/liboxia-native/src/client.rs
+++ b/liboxia-native/src/client.rs
@@ -449,7 +449,7 @@ impl OxiaClient {
         batcher: Batcher,
         key: &str,
     ) -> Result<(i64, Arc<BatchManager>), OxiaError> {
-        match self.inner.shard_manager.get_shard(&key) {
+        match self.inner.shard_manager.get_shard(key) {
             Some(shard_id) => self.get_or_init_batch_manager_with_shard(batcher, shard_id),
             None => Err(KeyLeaderNotFound(key.to_string())),
         }
@@ -467,8 +467,8 @@ impl OxiaClient {
                 self.inner.shard_manager.clone(),
                 self.inner.provider_manager.clone(),
                 self.inner.write_stream_manager.clone(),
-                self.inner.options.batch_linger.clone(),
-                self.inner.options.batch_max_size.clone(),
+                self.inner.options.batch_linger,
+                self.inner.options.batch_max_size,
             ))
         };
         let ref_mut = match batcher {
@@ -483,7 +483,7 @@ impl OxiaClient {
                 .entry(shard_id)
                 .or_insert_with(closure),
         };
-        Ok((ref_mut.key().clone(), ref_mut.value().clone()))
+        Ok((*ref_mut.key(), ref_mut.value().clone()))
     }
 }
 
@@ -518,7 +518,7 @@ impl Client for OxiaClient {
             .map_err(|err| UnexpectedStatus(err.to_string()))??;
         check_status(put_response.status)?;
         Ok(PutResult {
-            key: put_response.key.or(Some(key.clone())).unwrap(),
+            key: put_response.key.unwrap_or(key.clone()),
             version: put_response.version.unwrap(),
         })
     }
@@ -793,7 +793,7 @@ impl Client for OxiaClient {
     ) -> Result<Receiver<String>, OxiaError> {
         let mut manager_guard = self.inner.sequence_updates_manager.lock().await;
         let operation: GetSequenceUpdatesOperation = options.into();
-        if operation.partition_key == None {
+        if operation.partition_key.is_none() {
             return Err(IllegalArgument(
                 "required option: partition_key".to_string(),
             ));
@@ -949,23 +949,20 @@ async fn range_scan_from_single_shard(
         .await?
         .into_inner();
     let mut records = Vec::new();
-    loop {
-        match streaming.next().await {
-            Some(response) => match response {
-                Ok(response) => {
-                    for record in response.records {
-                        records.push(GetResult {
-                            key: record.key.unwrap(),
-                            value: record.value,
-                            version: record.version.unwrap(),
-                        })
-                    }
+    while let Some(response) = streaming.next().await {
+        match response {
+            Ok(response) => {
+                for record in response.records {
+                    records.push(GetResult {
+                        key: record.key.unwrap(),
+                        value: record.value,
+                        version: record.version.unwrap(),
+                    })
                 }
-                Err(err) => {
-                    return Err(UnexpectedStatus(err.to_string()));
-                }
-            },
-            None => break,
+            }
+            Err(err) => {
+                return Err(UnexpectedStatus(err.to_string()));
+            }
         }
     }
     Ok(RangeScanResult { records })
@@ -985,15 +982,12 @@ async fn list_from_single_shard(
         .await?
         .into_inner();
     let mut keys = Vec::new();
-    loop {
-        match streaming.next().await {
-            Some(response) => match response {
-                Ok(mut response) => keys.append(&mut response.keys),
-                Err(err) => {
-                    return Err(UnexpectedStatus(err.to_string()));
-                }
-            },
-            None => break,
+    while let Some(response) = streaming.next().await {
+        match response {
+            Ok(mut response) => keys.append(&mut response.keys),
+            Err(err) => {
+                return Err(UnexpectedStatus(err.to_string()));
+            }
         }
     }
     Ok(ListResult { keys })
@@ -1027,7 +1021,7 @@ async fn get_from_single_shard(
         .map_err(|err| UnexpectedStatus(err.to_string()))??;
     check_status(get_response.status)?;
     Ok(GetResult {
-        key: get_response.key.or(Some(extra_key)).unwrap(),
+        key: get_response.key.unwrap_or(extra_key),
         value: get_response.value,
         version: get_response.version.unwrap(),
     })

--- a/liboxia-native/src/lib.rs
+++ b/liboxia-native/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 mod address;
 mod batch;
 mod batch_manager;

--- a/liboxia-native/src/lib.rs
+++ b/liboxia-native/src/lib.rs
@@ -1,20 +1,20 @@
+mod address;
+mod batch;
+mod batch_manager;
 pub mod client;
 pub mod client_builder;
 pub mod client_options;
 pub mod errors;
-mod shard_manager;
-mod batch;
-mod operations;
-mod provider_manager;
-mod write_stream_manager;
-mod write_stream;
-mod batch_manager;
-mod address;
-mod session_manager;
-mod status;
 mod key;
 mod notification_manager;
+mod operations;
+mod provider_manager;
 mod sequence_updates_manager;
+mod session_manager;
+mod shard_manager;
+mod status;
+mod write_stream;
+mod write_stream_manager;
 
 #[allow(clippy::derive_partial_eq_without_eq)]
 pub mod oxia {

--- a/liboxia-native/src/notification_manager.rs
+++ b/liboxia-native/src/notification_manager.rs
@@ -9,7 +9,7 @@ use dashmap::DashMap;
 use futures::TryFutureExt;
 use log::{info, warn};
 use std::sync::atomic::{AtomicI64, Ordering};
-use std::sync::{Arc};
+use std::sync::Arc;
 use task::JoinHandle;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::Mutex;

--- a/liboxia-native/src/operations.rs
+++ b/liboxia-native/src/operations.rs
@@ -255,7 +255,7 @@ impl Clone for GetOperation {
             partition_key: self.partition_key.clone(),
             key: self.key.clone(),
             include_value: self.include_value,
-            comparison_type: self.comparison_type.clone(),
+            comparison_type: self.comparison_type,
             secondary_index_name: self.secondary_index_name.clone(),
         }
     }

--- a/liboxia-native/src/operations.rs
+++ b/liboxia-native/src/operations.rs
@@ -43,9 +43,7 @@ impl From<Vec<PutOption>> for PutOperation {
         let mut operation = PutOperation::default();
         for option in options {
             match option {
-                PutOption::ExpectedRecordNotExists() => {
-                    operation.expected_version_id = Some(-1)
-                }
+                PutOption::ExpectedRecordNotExists() => operation.expected_version_id = Some(-1),
                 PutOption::ExpectVersionId(expected_version_id) => {
                     operation.expected_version_id = Some(expected_version_id)
                 }

--- a/liboxia-native/src/provider_manager.rs
+++ b/liboxia-native/src/provider_manager.rs
@@ -15,10 +15,7 @@ impl ProviderManager {
         &self,
         address: String,
     ) -> Result<OxiaClientClient<Channel>, OxiaError> {
-        let once_cell = self
-            .providers
-            .entry(address.clone())
-            .or_insert_with(|| OnceCell::new());
+        let once_cell = self.providers.entry(address.clone()).or_default();
         let client = once_cell
             .get_or_try_init(|| async {
                 let client = OxiaClientClient::connect(address)

--- a/liboxia-native/src/sequence_updates_manager.rs
+++ b/liboxia-native/src/sequence_updates_manager.rs
@@ -19,7 +19,7 @@ pub struct SequenceUpdatesManager {
 }
 
 impl SequenceUpdatesManager {
-    pub  fn new(
+    pub fn new(
         key: String,
         partition_key: String,
         shard_manager: Arc<ShardManager>,

--- a/liboxia-native/src/session_manager.rs
+++ b/liboxia-native/src/session_manager.rs
@@ -1,8 +1,6 @@
 use crate::errors::OxiaError;
 use crate::errors::OxiaError::{SessionDoesNotExist, ShardLeaderNotFound, UnexpectedStatus};
-use crate::oxia::{
-    CloseSessionRequest, CreateSessionRequest, SessionHeartbeat,
-};
+use crate::oxia::{CloseSessionRequest, CreateSessionRequest, SessionHeartbeat};
 use crate::provider_manager::ProviderManager;
 use crate::shard_manager::ShardManager;
 use crate::status::CODE_SESSION_NOT_FOUND;

--- a/liboxia-native/src/session_manager.rs
+++ b/liboxia-native/src/session_manager.rs
@@ -184,10 +184,7 @@ impl SessionManager {
     }
 
     pub(crate) async fn get_session_id(&self, shard_id: i64) -> Result<i64, OxiaError> {
-        let session_cell = self
-            .sessions
-            .entry(shard_id)
-            .or_insert_with(|| OnceCell::new());
+        let session_cell = self.sessions.entry(shard_id).or_default();
         let session = session_cell
             .get_or_try_init(|| async {
                 match self.shard_manager.get_leader(shard_id) {

--- a/liboxia-native/src/shard_manager.rs
+++ b/liboxia-native/src/shard_manager.rs
@@ -1,6 +1,6 @@
 use crate::address::ensure_protocol;
 use crate::errors::OxiaError;
-use crate::errors::OxiaError::{UnexpectedStatus};
+use crate::errors::OxiaError::UnexpectedStatus;
 use crate::oxia::shard_assignment::ShardBoundaries;
 use crate::oxia::{ShardAssignment, ShardAssignmentsRequest};
 use crate::provider_manager::ProviderManager;

--- a/liboxia-native/src/write_stream.rs
+++ b/liboxia-native/src/write_stream.rs
@@ -50,11 +50,10 @@ impl WriteStream {
         let (tx, rx) = oneshot::channel();
         let inflight = Inflight { future: tx };
         inner_guard.inflight_deque.push_back(inflight);
-        let send_result = inner_guard.tx.send(request);
-        if send_result.is_err() {
+        if let Err(err) = inner_guard.tx.send(request) {
             inner_guard.alive = false;
             inner_guard.fail_inflight();
-            return Err(UnexpectedStatus(send_result.unwrap_err().to_string()));
+            return Err(UnexpectedStatus(err.to_string()));
         }
         drop(inner_guard);
         let mut guard = self.defer_response.lock().await;
@@ -74,11 +73,10 @@ impl WriteStream {
         let (tx, rx) = oneshot::channel();
         let inflight = Inflight { future: tx };
         inner_guard.inflight_deque.push_back(inflight);
-        let send_result = inner_guard.tx.send(request);
-        if send_result.is_err() {
+        if let Err(err) = inner_guard.tx.send(request) {
             inner_guard.alive = false;
             inner_guard.fail_inflight();
-            return Err(UnexpectedStatus(send_result.unwrap_err().to_string()));
+            return Err(UnexpectedStatus(err.to_string()));
         }
         drop(inner_guard);
         rx.await.map_err(|err| UnexpectedStatus(err.to_string()))
@@ -87,9 +85,7 @@ impl WriteStream {
     pub(crate) async fn get_defer_response(&self) -> Option<Result<WriteResponse, OxiaError>> {
         let mut guard = self.defer_response.lock().await;
         let option = guard.take();
-        if option.is_none() {
-            return None;
-        }
+        option.as_ref()?;
         Some(
             option
                 .unwrap()
@@ -146,27 +142,25 @@ async fn handle_response(
                 return
             },
             response = rx.next() => {
-                if response.is_none() {
+                let Some(response) = response else {
                     let mut inner_guard = inner.lock().await;
                     inner_guard.alive = false;
                     inner_guard.fail_inflight();
                     return;
-                }
-                match response.unwrap() {
+                };
+                match response {
                     Ok(write_response) => {
                         let mut inner_guard = inner.lock().await;
                         if !inner_guard.alive {
                             // stop loop and exit
                             return
                         }
-                        let inflight = inner_guard.inflight_deque.pop_front();
-                        if inflight.is_none() {
+                        let Some(inflight) = inner_guard.inflight_deque.pop_front() else {
                             warn!("Receive an empty write inflight, discard it.");
                             continue
-                        }
-                        let callback_result = inflight.unwrap().future.send(write_response); // it shouldn't happen
-                        if callback_result.is_err() {
-                            warn!("Send callback response failed. error: {:?}", callback_result.unwrap_err());
+                        };
+                        if let Err(err) = inflight.future.send(write_response) {
+                            warn!("Send callback response failed. error: {:?}", err);
                         }
                     }
                     Err(_status) => {

--- a/liboxia-native/src/write_stream_manager.rs
+++ b/liboxia-native/src/write_stream_manager.rs
@@ -26,16 +26,10 @@ impl WriteStreamManager {
     pub async fn write(&self, request: WriteRequest) -> Result<WriteResponse, OxiaError> {
         // todo: make request Rc
         loop {
-            let result = self.write0(request.clone()).await;
-            if result.is_ok() {
-                return result;
-            }
-            if result.is_err() {
-                let error = result.unwrap_err();
-                match error {
-                    InternalRetryable() => continue,
-                    _ => return Err(error),
-                }
+            match self.write0(request.clone()).await {
+                Ok(response) => return Ok(response),
+                Err(InternalRetryable()) => continue,
+                Err(err) => return Err(err),
             }
         }
     }
@@ -74,10 +68,7 @@ impl WriteStreamManager {
             w_stream.listen(streaming).await;
             Ok::<WriteStream, OxiaError>(w_stream)
         };
-        let mut cell = self
-            .streams
-            .entry(shard_id)
-            .or_insert_with(|| OnceCell::new());
+        let mut cell = self.streams.entry(shard_id).or_default();
         let initialized = cell.initialized();
         let w_stream = cell.get_or_try_init(defer_init).await?;
         if !w_stream.is_alive().await {

--- a/liboxia-native/tests/integration_tests.rs
+++ b/liboxia-native/tests/integration_tests.rs
@@ -1,7 +1,6 @@
 use liboxia::client::{
-    DeleteOption, DeleteRangeOption, GetOption,
-    KeyCreated, KeyDeleted, KeyModified, ListOption, Notification,
-    PutOption, RangeScanOption,
+    DeleteOption, DeleteRangeOption, GetOption, KeyCreated, KeyDeleted, KeyModified, ListOption,
+    Notification, PutOption, RangeScanOption,
 };
 use liboxia::client_builder::OxiaClientBuilder;
 use liboxia::errors::OxiaError;
@@ -61,10 +60,7 @@ async fn test_put_and_get() {
     let get_result = client.get("test/key1".to_string()).await.unwrap();
     assert_eq!(get_result.key, "test/key1");
     assert_eq!(get_result.value, Some(b"hello world".to_vec()));
-    assert_eq!(
-        get_result.version.version_id,
-        put_result.version.version_id
-    );
+    assert_eq!(get_result.version.version_id, put_result.version.version_id);
 
     client.shutdown().await.unwrap();
 }
@@ -161,10 +157,7 @@ async fn test_list() {
     let client = new_client(&address).await;
 
     for key in &["list/a", "list/b", "list/c"] {
-        client
-            .put(key.to_string(), b"v".to_vec())
-            .await
-            .unwrap();
+        client.put(key.to_string(), b"v".to_vec()).await.unwrap();
     }
 
     let result = client
@@ -192,10 +185,7 @@ async fn test_range_scan() {
 
     for i in 0..3 {
         client
-            .put(
-                format!("scan/{}", i),
-                format!("value-{}", i).into_bytes(),
-            )
+            .put(format!("scan/{}", i), format!("value-{}", i).into_bytes())
             .await
             .unwrap();
     }
@@ -330,9 +320,7 @@ async fn test_delete_with_expected_version() {
     client
         .delete_with_options(
             "delver/key".to_string(),
-            vec![DeleteOption::ExpectVersionId(
-                put_result.version.version_id,
-            )],
+            vec![DeleteOption::ExpectVersionId(put_result.version.version_id)],
         )
         .await
         .unwrap();
@@ -353,10 +341,7 @@ async fn test_get_floor() {
     let client = new_client(&address).await;
 
     for key in &["cmp/a", "cmp/c", "cmp/e"] {
-        client
-            .put(key.to_string(), b"v".to_vec())
-            .await
-            .unwrap();
+        client.put(key.to_string(), b"v".to_vec()).await.unwrap();
     }
 
     // Floor of "cmp/d" should be "cmp/c" (highest key <= "cmp/d")
@@ -382,10 +367,7 @@ async fn test_get_ceiling() {
     let client = new_client(&address).await;
 
     for key in &["cmp2/a", "cmp2/c", "cmp2/e"] {
-        client
-            .put(key.to_string(), b"v".to_vec())
-            .await
-            .unwrap();
+        client.put(key.to_string(), b"v".to_vec()).await.unwrap();
     }
 
     // Ceiling of "cmp2/b" should be "cmp2/c" (lowest key >= "cmp2/b")
@@ -411,10 +393,7 @@ async fn test_get_lower() {
     let client = new_client(&address).await;
 
     for key in &["cmp3/a", "cmp3/c", "cmp3/e"] {
-        client
-            .put(key.to_string(), b"v".to_vec())
-            .await
-            .unwrap();
+        client.put(key.to_string(), b"v".to_vec()).await.unwrap();
     }
 
     // Lower of "cmp3/c" should be "cmp3/a" (highest key < "cmp3/c")
@@ -440,10 +419,7 @@ async fn test_get_higher() {
     let client = new_client(&address).await;
 
     for key in &["cmp4/a", "cmp4/c", "cmp4/e"] {
-        client
-            .put(key.to_string(), b"v".to_vec())
-            .await
-            .unwrap();
+        client.put(key.to_string(), b"v".to_vec()).await.unwrap();
     }
 
     // Higher of "cmp4/c" should be "cmp4/e" (lowest key > "cmp4/c")
@@ -842,12 +818,9 @@ async fn test_client_clone_concurrent() {
     for i in 0..10 {
         let c = client.clone();
         handles.push(tokio::spawn(async move {
-            c.put(
-                format!("clone/{}", i),
-                format!("value-{}", i).into_bytes(),
-            )
-            .await
-            .unwrap();
+            c.put(format!("clone/{}", i), format!("value-{}", i).into_bytes())
+                .await
+                .unwrap();
             let get = c.get(format!("clone/{}", i)).await.unwrap();
             assert_eq!(get.value, Some(format!("value-{}", i).into_bytes()));
         }));
@@ -895,10 +868,7 @@ async fn test_version_metadata() {
 
     assert!(r2.version.version_id > r1.version.version_id);
     assert!(r2.version.modifications_count >= 1);
-    assert_eq!(
-        r2.version.created_timestamp,
-        r1.version.created_timestamp
-    );
+    assert_eq!(r2.version.created_timestamp, r1.version.created_timestamp);
     assert!(r2.version.modified_timestamp >= r1.version.modified_timestamp);
 
     client


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions CI workflow that runs on every PR and push to main
- Checks formatting (`cargo fmt`), linting (`cargo clippy`), build, and tests
- Uses cargo caching for faster runs

## Test plan
- [ ] Verify the workflow triggers on this PR
- [ ] Confirm fmt, clippy, build, and test steps pass