### PR TITLE
feat: add convenience re-exports at crate root

### DIFF
--- a/liboxia-native/src/lib.rs
+++ b/liboxia-native/src/lib.rs
@@ -21,3 +21,8 @@ mod write_stream_manager;
 pub mod oxia {
     include!(concat!(env!("OUT_DIR"), "/io.streamnative.oxia.proto.rs"));
 }
+
+// Convenience re-exports for common types
+pub use client::OxiaClient;
+pub use client_builder::OxiaClientBuilder;
+pub use errors::OxiaError;


### PR DESCRIPTION
## Summary
- Re-export key types at the crate root for ergonomic imports
- Users can now `use liboxia::OxiaClient` instead of `use liboxia::client::OxiaClient`

## Test plan
- [ ] CI passes (fmt, clippy, build, tests)