### PR TITLE
fix: improve retry behavior and cleanup unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,7 +980,6 @@ version = "0.0.2"
 dependencies = [
  "backoff",
  "dashmap",
- "futures",
  "log",
  "prost",
  "testcontainers",

--- a/liboxia-native/Cargo.toml
+++ b/liboxia-native/Cargo.toml
@@ -19,7 +19,6 @@ xxhash-rust = { workspace = true }
 uuid = { workspace = true }
 tokio-util = { workspace = true }
 log = { workspace = true }
-futures = { workspace = true }
 
 [dev-dependencies]
 tracing = { workspace = true }

--- a/liboxia-native/src/notification_manager.rs
+++ b/liboxia-native/src/notification_manager.rs
@@ -81,18 +81,19 @@ async fn start_notification_listener(
         let sender = sender.clone();
         async move {
             let mut provider = match shard_manager.get_leader(shard_id) {
-                None => Err(ShardLeaderNotFound(shard_id)),
-                Some(leader) => Ok(provider_manager
+                None => return Err(Error::transient(ShardLeaderNotFound(shard_id))),
+                Some(leader) => provider_manager
                     .get_provider(leader.service_address)
-                    .await?),
-            }?;
+                    .await
+                    .map_err(Error::transient)?,
+            };
             let mut streaming = provider
                 .get_notifications(NotificationsRequest {
                     shard: shard_id,
                     start_offset_exclusive: Some(offset_ref.load(Ordering::Acquire)),
                 })
-                .map_err(|err| UnexpectedStatus(err.to_string()))
-                .await?
+                .await
+                .map_err(|err| Error::transient(UnexpectedStatus(err.to_string())))?
                 .into_inner();
             loop {
                 tokio::select! {
@@ -104,13 +105,15 @@ async fn start_notification_listener(
                         None => {
                             return Err(Error::transient(UnexpectedStatus(String::from( "streaming has closed by server", )))); }
                         Some(notification) => {
-                            let batch = notification.map_err(|err| UnexpectedStatus(err.to_string()))?;
+                            let batch = notification.map_err(|err| {
+                                Error::transient(UnexpectedStatus(err.to_string()))
+                            })?;
                             offset_ref.store(batch.offset, Ordering::Release);
                             for notification_tuple in batch.notifications {
-                                    sender
-                                        .send(notification_tuple.into())
-                                        .await
-                                        .map_err(|err| UnexpectedStatus(err.to_string()))?;
+                                    if sender.send(notification_tuple.into()).await.is_err() {
+                                        // Receiver dropped, stop listening
+                                        return Ok(());
+                                    }
                             }
                     }
                 }

--- a/liboxia-native/src/notification_manager.rs
+++ b/liboxia-native/src/notification_manager.rs
@@ -6,7 +6,6 @@ use crate::provider_manager::ProviderManager;
 use crate::shard_manager::ShardManager;
 use backoff::{Error, ExponentialBackoff};
 use dashmap::DashMap;
-use futures::TryFutureExt;
 use log::{info, warn};
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;

--- a/liboxia-native/src/sequence_updates_manager.rs
+++ b/liboxia-native/src/sequence_updates_manager.rs
@@ -76,7 +76,8 @@ async fn start_listener(
                     Some(leader) => {
                         let mut provider = provider_manager
                             .get_provider(leader.service_address)
-                            .await?;
+                            .await
+                            .map_err(Error::transient)?;
                         let mut streaming = provider
                             .get_sequence_updates(Request::new(GetSequenceUpdatesRequest {
                                 shard,
@@ -94,14 +95,18 @@ async fn start_listener(
                                 next_response = streaming.next() => {
                                     match next_response {
                                     None => {
-                                        info!("Close shards assignment stream due to context canceled.");
-                                        return Ok(());
+                                        info!("Sequence updates stream closed by server.");
+                                        return Err(Error::transient(UnexpectedStatus(
+                                            "sequence updates stream closed by server".to_string(),
+                                        )));
                                     }
                                     Some(result) => {
                                         let response = result
                                             .map_err(|err| Error::transient(UnexpectedStatus(err.to_string())))?;
-                                         sender.send(response.highest_sequence_key).await
-                                            .map_err(|err| Error::transient(UnexpectedStatus(err.to_string())))?;
+                                        if sender.send(response.highest_sequence_key).await.is_err() {
+                                            // Receiver dropped, stop listening
+                                            return Ok(());
+                                        }
                                     }}
                                 }
                             }

--- a/liboxia-native/src/session_manager.rs
+++ b/liboxia-native/src/session_manager.rs
@@ -89,7 +89,8 @@ async fn start_keep_alive(
                 Some(leader) => {
                     let mut provider = local_provider_manager
                         .get_provider(leader.service_address)
-                        .await?;
+                        .await
+                        .map_err(Error::transient)?;
                     let mut ticker = interval(heartbeat_interval);
                     loop {
                         tokio::select! {
@@ -197,7 +198,7 @@ impl SessionManager {
                         let response = provider
                             .create_session(Request::new(CreateSessionRequest {
                                 shard: shard_id,
-                                session_timeout_ms: self.session_timeout.clone().as_millis() as u32,
+                                session_timeout_ms: self.session_timeout.as_millis() as u32,
                                 client_identity: self.identity.clone(),
                             }))
                             .await


### PR DESCRIPTION
## Summary
- Improve retry behavior in notification and sequence update managers
- Remove unused `futures` dependency
- Fix session keep-alive retry logic and minor cleanup

## Test plan
- [ ] CI passes (fmt, clippy, build, tests)