### PR TITLE
fix: route shard keys with XXH3-32 to match server and other SDKs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ prost = "0.13"
 tokio = { version = "1.47.0", features = ["rt-multi-thread", "macros"] }
 thiserror = "2.0.12"
 dashmap = "6.1.0"
-xxhash-rust = { version = "0.8.5", features = ["xxh32", "const_xxh32"] }
+xxhash-rust = { version = "0.8.5", features = ["xxh3"] }
 uuid = { version = "1.7", features = ["v4"] }
 tokio-util = "0.7"
 log = "0.4"

--- a/liboxia-native/src/hash.rs
+++ b/liboxia-native/src/hash.rs
@@ -1,0 +1,68 @@
+//! Key-to-shard hashing.
+//!
+//! Oxia routes a key to a shard by hashing it and locating the shard whose
+//! hash range contains the result. The hash must match the server and every
+//! other Oxia client SDK exactly, otherwise a key written by one client is
+//! looked up on the wrong shard by another.
+
+use crate::oxia::ShardKeyRouter;
+use log::warn;
+
+/// Hashes `key` with the algorithm Oxia uses for shard routing: the low 32
+/// bits of the 64-bit XXH3 digest (seed 0).
+///
+/// This mirrors the Go reference implementation in `common/hash/hash.go`,
+/// `uint32(xxh3.HashString(key))`, which is what the coordinator uses to
+/// compute shard hash-range boundaries.
+pub(crate) fn xxh3_32(key: &str) -> u32 {
+    xxhash_rust::xxh3::xxh3_64(key.as_bytes()) as u32
+}
+
+/// Hashes `key` using the algorithm advertised by the namespace's
+/// [`ShardKeyRouter`].
+///
+/// `XXHASH3` is the only routing algorithm Oxia defines. `UNKNOWN` (sent by
+/// servers that predate the field) is treated as `XXHASH3` for compatibility,
+/// matching the Go client, which always routes with XXH3. Any value we do not
+/// recognize is logged and falls back to `XXHASH3` — the only algorithm that
+/// has ever existed — rather than silently routing with a mismatched hash.
+pub(crate) fn shard_key_hash(router: i32, key: &str) -> u32 {
+    match ShardKeyRouter::try_from(router) {
+        Ok(ShardKeyRouter::Xxhash3) | Ok(ShardKeyRouter::Unknown) => xxh3_32(key),
+        Err(_) => {
+            warn!("Unrecognized shard key router {router}; routing with XXHASH3");
+            xxh3_32(key)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Vectors taken verbatim from the Go reference test
+    /// (`common/hash/hash_test.go`). If these diverge, keys placed by this
+    /// client land on different shards than every other Oxia client.
+    #[test]
+    fn matches_upstream_vectors() {
+        assert_eq!(xxh3_32("foo"), 125730186);
+        assert_eq!(xxh3_32("bar"), 2687685474);
+        assert_eq!(xxh3_32("baz"), 862947621);
+    }
+
+    #[test]
+    fn router_dispatch_selects_xxhash3() {
+        // The declared XXHASH3 router.
+        assert_eq!(
+            shard_key_hash(ShardKeyRouter::Xxhash3 as i32, "foo"),
+            xxh3_32("foo")
+        );
+        // UNKNOWN (older servers that do not set the field) → XXHASH3.
+        assert_eq!(
+            shard_key_hash(ShardKeyRouter::Unknown as i32, "foo"),
+            xxh3_32("foo")
+        );
+        // An unrecognized future router falls back to XXHASH3.
+        assert_eq!(shard_key_hash(999, "foo"), xxh3_32("foo"));
+    }
+}

--- a/liboxia-native/src/lib.rs
+++ b/liboxia-native/src/lib.rs
@@ -6,6 +6,7 @@ pub mod client;
 pub mod client_builder;
 pub mod client_options;
 pub mod errors;
+mod hash;
 mod key;
 mod notification_manager;
 mod operations;

--- a/liboxia-native/src/shard_manager.rs
+++ b/liboxia-native/src/shard_manager.rs
@@ -1,13 +1,15 @@
 use crate::address::ensure_protocol;
 use crate::errors::OxiaError;
 use crate::errors::OxiaError::UnexpectedStatus;
+use crate::hash::shard_key_hash;
 use crate::oxia::shard_assignment::ShardBoundaries;
-use crate::oxia::{ShardAssignment, ShardAssignmentsRequest};
+use crate::oxia::{ShardAssignment, ShardAssignmentsRequest, ShardKeyRouter};
 use crate::provider_manager::ProviderManager;
 use backoff::{Error, ExponentialBackoff};
 use dashmap::DashMap;
 use log::{info, warn};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
 use tokio::task::JoinHandle;
@@ -26,6 +28,9 @@ pub(crate) struct Node {
 struct Inner {
     provider_manager: Arc<ProviderManager>,
     current_assignments: Arc<DashMap<i64, ShardAssignment>>,
+    /// The [`ShardKeyRouter`] most recently advertised by the namespace, stored
+    /// as its raw enum value. Determines which hash routes keys to shards.
+    shard_key_router: AtomicI32,
 }
 
 pub struct ShardManager {
@@ -84,10 +89,14 @@ async fn start_assignments_listener(
                             if ns_assignments.is_none() {
                                     continue;
                             }
+                            let namespace_assignment = ns_assignments.unwrap();
                             assignments_ref.clear();
-                            for sa in &ns_assignments.unwrap().assignments {
+                            for sa in &namespace_assignment.assignments {
                                 assignments_ref.insert(sa.shard, sa.clone());
                             }
+                            local_inner
+                                .shard_key_router
+                                .store(namespace_assignment.shard_key_router, Ordering::Release);
                             if !init_sender.is_closed() {
                                 let _ = init_sender.send(()).await;
                             }
@@ -117,6 +126,7 @@ impl ShardManager {
         let inner = Arc::new(Inner {
             provider_manager: options.provider_manager,
             current_assignments: Arc::new(DashMap::new()),
+            shard_key_router: AtomicI32::new(ShardKeyRouter::Xxhash3 as i32),
         });
         let (init_tx, mut init_rx) = mpsc::channel(1);
         let assignment_handle = tokio::spawn(start_assignments_listener(
@@ -155,7 +165,7 @@ impl ShardManager {
     }
 
     pub fn get_shard(&self, key: &str) -> Option<i64> {
-        let code = xxhash_rust::xxh32::xxh32(key.as_bytes(), 0);
+        let code = shard_key_hash(self.inner.shard_key_router.load(Ordering::Acquire), key);
         for entry in self.inner.current_assignments.iter() {
             if let Some(boundaries) = entry.shard_boundaries.as_ref() {
                 match boundaries {
@@ -184,7 +194,7 @@ impl ShardManager {
     }
 
     pub fn get_shard_leader(&self, key: &str) -> Option<Node> {
-        let code = xxhash_rust::xxh32::xxh32(key.as_bytes(), 0);
+        let code = shard_key_hash(self.inner.shard_key_router.load(Ordering::Acquire), key);
         for entry in self.inner.current_assignments.iter() {
             if let Some(boundaries) = entry.shard_boundaries.as_ref() {
                 match boundaries {


### PR DESCRIPTION
## What

Fix key→shard routing to use **XXH3-32** (the low 32 bits of the 64-bit XXH3 digest, seed 0) instead of the classic **XXH32** the client used before.

- New `liboxia-native/src/hash.rs`: `xxh3_32(key) = xxhash_rust::xxh3::xxh3_64(key.as_bytes()) as u32`.
- `shard_manager.rs` now routes through the `ShardKeyRouter` advertised in the namespace assignment (captured into an `AtomicI32`), via `shard_key_hash(router, key)`.
- `xxhash-rust` feature swapped `xxh32` → `xxh3`.

## Why

The Oxia server and every other client SDK route with `uint32(xxh3.HashString(key))` — see the Go reference [`common/hash/hash.go`](https://github.com/oxia-db/oxia/blob/main/common/hash/hash.go). Classic XXH32 and XXH3-32 are different algorithms with different outputs, so before this change:

- a key written by this client could be looked up on the **wrong shard** by a Go/Java client on the same namespace (broken cross-client interop);
- records could be **stranded across shard splits**, since split points are computed with the canonical hash.

It went unnoticed because a single Rust client is internally self-consistent, and plain `EQUAL` gets currently broadcast to all shards (a separate follow-up).

## How it's verified

`hash.rs` unit-tests assert the exact upstream vectors from Go's `common/hash/hash_test.go` — `foo→125730186`, `bar→2687685474`, `baz→862947621` — and they **pass**, confirming `xxhash-rust`'s XXH3 is byte-identical to Go's `zeebo/xxh3` here.

```
cargo fmt --all --check          # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test -p liboxia --lib      # 14 passed (incl. 2 new hash tests)
```

## Reviewer notes

- **Router dispatch is stricter than the Go client.** The Go reference hardcodes XXH3 and ignores `shard_key_router`; this PR recognizes the router and warns-then-defaults-to-XXH3 on any unrecognized value, so a future protocol change surfaces loudly instead of silently mis-routing. Effective behavior today is identical to Go (always XXH3). A hard fail-closed error on unknown routers was deferred to avoid rippling `Result` through many `Option`-returning call sites (planned with the shard-manager rework).
- **Not yet covered here:** end-to-end Go↔Rust interop against a live multi-shard cluster — tracked as a follow-up.

Corresponds to tasks P0-1 (hash), P0-2 (vectors), P0-3 (router dispatch) of the SDK roadmap.