### PR TITLE
fix: migrate client to the io.oxia.proto.v1 gRPC service

### DIFF
--- a/liboxia-native/proto/client.proto
+++ b/liboxia-native/proto/client.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 StreamNative, Inc.
+// Copyright 2023-2026 The Oxia Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
  */
 syntax = "proto3";
 
-package io.streamnative.oxia.proto;
+package io.oxia.proto.v1;
 
-option go_package = "github.com/oxia-db/oxia/proto";
+option go_package = "github.com/oxia-db/oxia/common/proto";
 option java_multiple_files = true;
 
 /**
@@ -128,6 +128,7 @@ message ShardAssignmentsRequest {
  */
 message ShardAssignments {
   map<string, NamespaceShardsAssignment> namespaces = 1;
+  repeated string allowed_authorities = 2;
 }
 
 /**
@@ -264,6 +265,11 @@ message PutRequest {
   repeated uint64 sequence_key_delta = 7;
 
   repeated SecondaryIndex secondary_indexes = 8;
+
+  // Optional overrides for version metadata, used during data migration.
+  // When set, the server will use these values instead of auto-generating them.
+  optional int64 override_version_id = 9;
+  optional int64 override_modifications_count = 10;
 }
 
 /**
@@ -377,6 +383,8 @@ message ListRequest {
   string end_exclusive = 3;
 
   optional string secondary_index_name = 4;
+
+  bool include_internal_keys = 5;
 }
 
 /**
@@ -400,6 +408,8 @@ message RangeScanRequest {
   string end_exclusive = 3;
 
   optional string secondary_index_name = 4;
+
+  bool include_internal_keys = 5;
 }
 
 /**
@@ -497,7 +507,20 @@ message NotificationBatch {
   int64 offset = 2;
   fixed64 timestamp = 3;
 
-  map<string, Notification> notifications = 4;
+  // Wire-compatible with the former `map<string, Notification>` field: a map
+  // entry encodes exactly as NotificationEntry{key = 1, value = 2}. The
+  // server emits entries sorted by key, because the serialized batch feeds
+  // the replicated checksum and must be byte-identical on every replica —
+  // generated marshalers emit repeated fields in slice order, which makes
+  // that determinism structural instead of requiring a special marshaler.
+  repeated NotificationEntry notifications = 4;
+}
+
+message NotificationEntry {
+  // optional: presence-tracked, so the field is emitted even for an empty
+  // key, exactly as a map entry encodes it
+  optional string key = 1;
+  Notification value = 2;
 }
 
 message Notification {

--- a/liboxia-native/src/client.rs
+++ b/liboxia-native/src/client.rs
@@ -215,9 +215,12 @@ impl fmt::Display for Notification {
     }
 }
 
-impl From<(String, crate::oxia::Notification)> for Notification {
-    fn from(tuple: (String, crate::oxia::Notification)) -> Self {
-        let (key, notification) = tuple;
+impl From<crate::oxia::NotificationEntry> for Notification {
+    fn from(entry: crate::oxia::NotificationEntry) -> Self {
+        let key = entry.key.unwrap_or_default();
+        let Some(notification) = entry.value else {
+            return Notification::Unknown();
+        };
         if let Ok(notification_type) = NotificationType::try_from(notification.r#type) {
             return match notification_type {
                 NotificationType::KeyCreated => Notification::KeyCreated(KeyCreated {

--- a/liboxia-native/src/lib.rs
+++ b/liboxia-native/src/lib.rs
@@ -20,7 +20,7 @@ mod write_stream_manager;
 
 #[allow(clippy::derive_partial_eq_without_eq)]
 pub mod oxia {
-    include!(concat!(env!("OUT_DIR"), "/io.streamnative.oxia.proto.rs"));
+    include!(concat!(env!("OUT_DIR"), "/io.oxia.proto.v1.rs"));
 }
 
 // Convenience re-exports for common types

--- a/liboxia-native/src/notification_manager.rs
+++ b/liboxia-native/src/notification_manager.rs
@@ -108,8 +108,8 @@ async fn start_notification_listener(
                                 Error::transient(UnexpectedStatus(err.to_string()))
                             })?;
                             offset_ref.store(batch.offset, Ordering::Release);
-                            for notification_tuple in batch.notifications {
-                                    if sender.send(notification_tuple.into()).await.is_err() {
+                            for entry in batch.notifications {
+                                    if sender.send(entry.into()).await.is_err() {
                                         // Receiver dropped, stop listening
                                         return Ok(());
                                     }

--- a/liboxia-native/src/operations.rs
+++ b/liboxia-native/src/operations.rs
@@ -74,6 +74,9 @@ impl ToProtobuf<PutRequest> for PutOperation {
             partition_key: self.partition_key.clone(),
             sequence_key_delta: self.sequence_key_delta.clone(),
             secondary_indexes: self.secondary_indexes.clone(),
+            // Server-side version overrides, used only by data-migration tooling.
+            override_version_id: None,
+            override_modifications_count: None,
         }
     }
 }
@@ -354,6 +357,7 @@ impl ToProtobuf<ListRequest> for ListOperation {
             start_inclusive: self.min_key_inclusive.clone(),
             end_exclusive: self.max_key_exclusive.clone(),
             secondary_index_name: self.secondary_index_name.clone(),
+            include_internal_keys: false,
         }
     }
 }
@@ -420,6 +424,7 @@ impl ToProtobuf<RangeScanRequest> for RangeScanOperation {
             start_inclusive: self.min_key_inclusive.clone(),
             end_exclusive: self.max_key_exclusive.clone(),
             secondary_index_name: self.secondary_index_name.clone(),
+            include_internal_keys: false,
         }
     }
 }


### PR DESCRIPTION
## What

Re-vendor `liboxia-native/proto/client.proto` from upstream `oxia-db/oxia` (`common/proto/client.proto`) and switch the generated gRPC service path from the legacy `io.streamnative.oxia.proto` package to **`io.oxia.proto.v1`**. The `include!` in `lib.rs` now points at the regenerated `io.oxia.proto.v1.rs`, so RPCs travel over `io.oxia.proto.v1.OxiaClient/*`.

## Why

Upstream renamed the proto package. Modern servers serve the native `io.oxia.proto.v1` service and keep the old `io.streamnative.oxia.proto` path alive only through a **temporary compat shim** — its own comment says *"Once all the old clients are upgraded, this will be removed."* A native client should speak v1 directly rather than depend on a shim scheduled for deletion.

**Decision (D-2): drop old-server support.** This client now **requires a server that serves `io.oxia.proto.v1`** and does not fall back to the legacy path. A minimum-server-version note for the README is tracked separately.

## Proto changes pulled in, and how the client adapts

- **`NotificationBatch.notifications`**: `map<string, Notification>` → sorted `repeated NotificationEntry`. The conversion was rewritten to consume `NotificationEntry`. Side benefit: intra-batch notifications now arrive in the server's deterministic key order instead of random `HashMap` order (previously an ordering bug).
- **`PutRequest`**: new `override_version_id` / `override_modifications_count` (data-migration tooling only) — client sends `None`.
- **`ListRequest` / `RangeScanRequest`**: new `include_internal_keys` — client sends `false`, keeping Oxia's internal keys hidden.

`Cargo.toml`, `build.rs`, and the `OxiaClient` service/RPC set are unchanged; the service and all RPC names are identical between the two packages.

## Verification

- Regenerated output confirmed as `io.oxia.proto.v1.rs`.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build`: clean.
- 14 unit tests pass; integration tests compile against the new proto and run against `oxia/oxia:main` (a modern v1 server) under Docker.

## Reviewer notes

- Diff is against `main` after #24 (XXH3 routing fix) merged; this PR contains only the proto migration.
- Requires Docker + `oxia/oxia:main` to run the integration suite end-to-end (the P0 gate).

Corresponds to roadmap tasks P0-4 (re-vendor + regenerate) and P0-5 (v1 service path), and decision D-2.