### PR TITLE
test: Go↔Rust interop tests + fix slash-aware key ordering

### DIFF
--- a/oxia-client/src/key.rs
+++ b/oxia-client/src/key.rs
@@ -1,41 +1,35 @@
 use std::cmp::Ordering;
 
+/// Compares two keys using Oxia's slash-aware ordering.
+///
+/// This must match the server and every other Oxia client — it is a direct port
+/// of the Go reference `common/compare.CompareWithSlash`. Comparison proceeds
+/// segment by segment, splitting on `/`; at any level a key with no further `/`
+/// sorts *before* one that has a deeper segment, regardless of the remaining
+/// bytes. `list` and `range_scan` merge per-shard results with this order, so it
+/// has to agree with the server exactly.
 pub fn compare(mut a: &str, mut b: &str) -> Ordering {
-    loop {
-        let idx_a = a.find('/');
-        let idx_b = b.find('/');
-        match (idx_a, idx_b) {
-            (None, None) => {
-                return a.cmp(b);
-            }
-            (None, Some(_)) => {
-                let b_span = &b[..idx_b.unwrap()];
-                let span_res = a.cmp(b_span);
-                if span_res != Ordering::Equal {
-                    return span_res;
-                }
-                return Ordering::Less;
-            }
-            (Some(_), None) => {
-                let a_span = &a[..idx_a.unwrap()];
-                let span_res = a_span.cmp(b);
-                if span_res != Ordering::Equal {
-                    return span_res;
-                }
-                return Ordering::Greater;
-            }
+    while !a.is_empty() && !b.is_empty() {
+        match (a.find('/'), b.find('/')) {
+            // Neither has a further separator: plain byte-wise comparison.
+            (None, None) => return a.cmp(b),
+            // The side that ends first (no more `/`) sorts before the deeper one,
+            // independent of the bytes — this is the crux of the ordering.
+            (None, Some(_)) => return Ordering::Less,
+            (Some(_), None) => return Ordering::Greater,
+            // Both have another segment: compare this segment, else descend.
             (Some(ia), Some(ib)) => {
-                let span_a = &a[..ia];
-                let span_b = &b[..ib];
-                let span_res = span_a.cmp(span_b);
-                if span_res != Ordering::Equal {
-                    return span_res;
+                let span = a[..ia].cmp(&b[..ib]);
+                if span != Ordering::Equal {
+                    return span;
                 }
                 a = &a[ia + 1..];
                 b = &b[ib + 1..];
             }
         }
     }
+    // One side is exhausted: the shorter key sorts first.
+    a.len().cmp(&b.len())
 }
 #[cfg(test)]
 mod tests {
@@ -78,8 +72,35 @@ mod tests {
     fn test_empty_segments() {
         assert_eq!(compare("a//c", "a/b/c"), Ordering::Less);
         assert_eq!(compare("a/b", "a/b/"), Ordering::Less);
-        assert_eq!(compare("a//", "a/b"), Ordering::Less);
+        // "a//" descends to "/" vs "b": "/" has a further segment, "b" does not,
+        // so "a//" sorts after "a/b". (Matches the Go reference; the pre-fix
+        // implementation wrongly returned Less by comparing bytes first.)
+        assert_eq!(compare("a//", "a/b"), Ordering::Greater);
         assert_eq!(compare("", "a/b"), Ordering::Less);
+    }
+
+    /// Vectors copied verbatim from the Go reference
+    /// (`common/compare/compare_with_slash_test.go`). If these diverge, this
+    /// client orders `list`/`range_scan` results differently from the server and
+    /// every other Oxia client.
+    #[test]
+    fn matches_go_compare_with_slash_vectors() {
+        assert_eq!(compare("aaaaa", "aaaaa"), Ordering::Equal);
+        assert_eq!(compare("aaaaa", "zzzzz"), Ordering::Less);
+        assert_eq!(compare("bbbbb", "aaaaa"), Ordering::Greater);
+        assert_eq!(compare("aaaaa", ""), Ordering::Greater);
+        assert_eq!(compare("", "aaaaaa"), Ordering::Less);
+        assert_eq!(compare("", ""), Ordering::Equal);
+        assert_eq!(compare("aaaaa", "aaaaaaaaaaa"), Ordering::Less);
+        assert_eq!(compare("aaaaaaaaaaa", "aaa"), Ordering::Greater);
+        assert_eq!(compare("a", "/"), Ordering::Less);
+        assert_eq!(compare("/", "a"), Ordering::Greater);
+        assert_eq!(compare("/aaaa", "/bbbbb"), Ordering::Less);
+        assert_eq!(compare("/aaaa", "/aa/a"), Ordering::Less);
+        assert_eq!(compare("/aaaa/a", "/aaaa/b"), Ordering::Less);
+        assert_eq!(compare("/aaaa/a/a", "/bbbbbbbbbb"), Ordering::Greater);
+        assert_eq!(compare("/aaaa/a/a", "/aaaa/bbbbbbbbbb"), Ordering::Greater);
+        assert_eq!(compare("/a/b/a/a/a", "/a/b/a/b"), Ordering::Greater);
     }
 
     #[test]

--- a/oxia-client/tests/interop_tests.rs
+++ b/oxia-client/tests/interop_tests.rs
@@ -1,0 +1,125 @@
+//! Cross-client interop tests: the Rust client and the reference Go client (the
+//! `oxia` CLI shipped in the server image) must agree on how keys are routed to
+//! shards. Both are exercised against the same multi-shard namespace.
+//!
+//! The routing-critical direction is "Rust writes, Go reads": the Go CLI does a
+//! single-shard get, so if the two clients hashed keys differently, Go would
+//! look on the wrong shard and fail to find records the Rust client wrote.
+
+use oxia::client_builder::OxiaClientBuilder;
+use std::time::Duration;
+use testcontainers::core::ports::ContainerPort;
+use testcontainers::core::wait::WaitFor;
+use testcontainers::core::{CmdWaitFor, ExecCommand};
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, GenericImage, ImageExt};
+
+const OXIA_PORT: u16 = 6648;
+const DEFAULT_OXIA_IMAGE: &str = "oxia/oxia";
+const DEFAULT_OXIA_TAG: &str = "main";
+const SHARDS: u32 = 10;
+const KEY_COUNT: usize = 24;
+
+/// Starts a standalone Oxia server with `SHARDS` shards so keys actually spread
+/// across shards and routing is exercised.
+async fn start_oxia_multishard() -> (ContainerAsync<GenericImage>, String) {
+    let image = std::env::var("OXIA_IMAGE").unwrap_or_else(|_| DEFAULT_OXIA_IMAGE.to_string());
+    let tag = std::env::var("OXIA_TAG").unwrap_or_else(|_| DEFAULT_OXIA_TAG.to_string());
+
+    let container = GenericImage::new(image, tag)
+        .with_exposed_port(ContainerPort::Tcp(OXIA_PORT))
+        .with_wait_for(WaitFor::message_on_stdout("Started Grpc server"))
+        .with_cmd(vec![
+            "oxia".to_string(),
+            "standalone".to_string(),
+            "--shards".to_string(),
+            SHARDS.to_string(),
+        ])
+        .start()
+        .await
+        .expect("Failed to start Oxia container");
+
+    let host_port = container
+        .get_host_port_ipv4(OXIA_PORT)
+        .await
+        .expect("Failed to get host port");
+    (container, format!("http://127.0.0.1:{}", host_port))
+}
+
+async fn new_client(address: &str) -> oxia::client::OxiaClient {
+    OxiaClientBuilder::new()
+        .service_address(address.to_string())
+        .request_timeout(Duration::from_secs(10))
+        .build()
+        .await
+        .unwrap()
+}
+
+/// Runs `oxia client <args>` (the Go client) inside the container and returns
+/// its trimmed stdout. Requires exit code 0, so a failed get/put panics.
+async fn oxia_cli(container: &ContainerAsync<GenericImage>, args: &[&str]) -> String {
+    let mut cmd: Vec<String> = vec!["oxia".to_string(), "client".to_string()];
+    cmd.extend(args.iter().map(|s| s.to_string()));
+    let mut result = container
+        .exec(ExecCommand::new(cmd).with_cmd_ready_condition(CmdWaitFor::exit_code(0)))
+        .await
+        .unwrap_or_else(|e| panic!("`oxia client {}` failed: {e}", args.join(" ")));
+    let out = result.stdout_to_vec().await.expect("read exec stdout");
+    String::from_utf8(out)
+        .expect("exec stdout is not utf-8")
+        .trim_end()
+        .to_string()
+}
+
+/// Rust writes across shards; the Go CLI must find every record on the shard it
+/// routes to. A routing-hash mismatch would make the Go get fail (KeyNotFound).
+#[tokio::test]
+async fn rust_writes_go_reads_across_shards() {
+    let (container, address) = start_oxia_multishard().await;
+    let client = new_client(&address).await;
+
+    for i in 0..KEY_COUNT {
+        let key = format!("interop/rust-{i}");
+        let value = format!("rust-value-{i}");
+        client
+            .put(key, value.into_bytes())
+            .await
+            .expect("rust put failed");
+    }
+
+    for i in 0..KEY_COUNT {
+        let key = format!("interop/rust-{i}");
+        let expected = format!("rust-value-{i}");
+        let got = oxia_cli(&container, &["get", &key]).await;
+        assert_eq!(got, expected, "Go CLI read the wrong value for {key}");
+    }
+
+    client.shutdown().await.unwrap();
+}
+
+/// The Go CLI writes across shards; the Rust client must read every value back,
+/// confirming value/proto round-tripping across clients.
+#[tokio::test]
+async fn go_writes_rust_reads_across_shards() {
+    let (container, address) = start_oxia_multishard().await;
+    let client = new_client(&address).await;
+
+    for i in 0..KEY_COUNT {
+        let key = format!("interop/go-{i}");
+        let value = format!("go-value-{i}");
+        oxia_cli(&container, &["put", &key, &value]).await;
+    }
+
+    for i in 0..KEY_COUNT {
+        let key = format!("interop/go-{i}");
+        let expected = format!("go-value-{i}");
+        let got = client.get(key.clone()).await.expect("rust get failed");
+        assert_eq!(
+            got.value.as_deref(),
+            Some(expected.as_bytes()),
+            "Rust read the wrong value for {key}"
+        );
+    }
+
+    client.shutdown().await.unwrap();
+}


### PR DESCRIPTION
Closes Phase 0 (P0-6 + the P0-G gate): cross-client interop coverage that locks the XXH3-32 routing fix and the proto migration, plus a real key-ordering bug it uncovered.

## Two commits

### 1. `fix:` correct slash-aware key ordering to match the server
`key::compare` diverged from the Go reference (`common/compare.CompareWithSlash`). When one key had no further `/` and the other did, it compared the remaining **bytes** first instead of ordering the shorter (leaf) key first — returning e.g. `"a" > "/"` and `"/aaaa" > "/aa/a"`, the **opposite** of the server. Since `list()`/`range_scan()` merge per-shard results with this comparator, multi-shard results could be ordered differently from the server and from Go/Java clients.

- Ported the Go algorithm exactly; added its upstream test vectors (`matches_go_compare_with_slash_vectors`).
- One existing unit test asserted the pre-fix (wrong) result for `"a//"` vs `"a/b"` — corrected to `Greater` to match the reference. (This is the test encoding the bug, not the fix chasing the test — the new Go-vector test is the independent check.)

### 2. `test:` add Go↔Rust cross-client interop tests
New `oxia-client/tests/interop_tests.rs` runs the reference Go client (the `oxia` CLI in the server image, via `docker exec`) against the **same 10-shard standalone namespace** as the Rust client:

| Test | What it proves |
|---|---|
| `rust_writes_go_reads_across_shards` | Rust writes keys spread across shards; the Go CLI (single-shard get) must find each on the shard it routes to. A routing-hash mismatch → `KeyNotFound`. **This is the routing lock.** |
| `go_writes_rust_reads_across_shards` | Reverse direction — values round-trip across clients. |

## Verification (run locally against `oxia/oxia:main`)

- `cargo test -p oxia-client --lib` → 15 pass (incl. the new Go key-order vectors and the existing hash vectors).
- `cargo test --test interop_tests` → **2 pass** against a real 10-shard container.
- `cargo test --test integration_tests` → **45 pass** — the ordering-sensitive ones (`test_list`, `test_range_scan`, `test_range_scan_values`, `test_list_partial_range`) confirm the `compare` change regressed nothing.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean.

No `ci.yml` change needed: the new tests run under the existing `cargo test --workspace` (Docker is available on the runners), alongside the current integration suite. That satisfies the P0-G gate.