### PR TITLE
refactor: typed error taxonomy with is_retryable() (P1-1)

### DIFF
--- a/oxia-client-ffi/oxia_client_ffi.h
+++ b/oxia-client-ffi/oxia_client_ffi.h
@@ -12,18 +12,19 @@
 
 enum COxiaError {
   Ok = 0,
-  TransportError = 1,
-  GrpcStatus = 2,
-  UnexpectedStatus = 3,
-  ShardLeaderNotFound = 4,
-  KeyLeaderNotFound = 5,
-  KeyNotFound = 6,
-  UnexpectedVersionId = 7,
-  SessionDoesNotExist = 8,
-  InternalRetryable = 9,
-  Cancelled = 10,
-  IllegalArgument = 11,
-  RequestTimeout = 12,
+  KeyNotFound = 1,
+  UnexpectedVersionId = 2,
+  SessionExpired = 3,
+  RequestTooLarge = 4,
+  InvalidArgument = 5,
+  LeaderNotFound = 6,
+  NoShardForKey = 7,
+  Disconnected = 8,
+  Timeout = 9,
+  Grpc = 10,
+  Decode = 11,
+  Closed = 12,
+  Other = 13,
 };
 typedef int32_t COxiaError;
 

--- a/oxia-client-ffi/src/lib.rs
+++ b/oxia-client-ffi/src/lib.rs
@@ -45,35 +45,38 @@ pub struct COxiaGetResult {
 #[derive(Debug, PartialEq)]
 pub enum COxiaError {
     Ok = 0,
-    TransportError = 1,
-    GrpcStatus = 2,
-    UnexpectedStatus = 3,
-    ShardLeaderNotFound = 4,
-    KeyLeaderNotFound = 5,
-    KeyNotFound = 6,
-    UnexpectedVersionId = 7,
-    SessionDoesNotExist = 8,
-    InternalRetryable = 9,
-    Cancelled = 10,
-    IllegalArgument = 11,
-    RequestTimeout = 12,
+    KeyNotFound = 1,
+    UnexpectedVersionId = 2,
+    SessionExpired = 3,
+    RequestTooLarge = 4,
+    InvalidArgument = 5,
+    LeaderNotFound = 6,
+    NoShardForKey = 7,
+    Disconnected = 8,
+    Timeout = 9,
+    Grpc = 10,
+    Decode = 11,
+    Closed = 12,
+    Other = 13,
 }
 
 impl From<OxiaError> for COxiaError {
     fn from(error: OxiaError) -> Self {
         match error {
-            OxiaError::Transport(_) => COxiaError::TransportError,
-            OxiaError::GrpcStatus(_) => COxiaError::GrpcStatus,
-            OxiaError::UnexpectedStatus(_) => COxiaError::UnexpectedStatus,
-            OxiaError::ShardLeaderNotFound(_) => COxiaError::ShardLeaderNotFound,
-            OxiaError::KeyLeaderNotFound(_) => COxiaError::KeyLeaderNotFound,
-            OxiaError::KeyNotFound() => COxiaError::KeyNotFound,
-            OxiaError::UnexpectedVersionId() => COxiaError::UnexpectedVersionId,
-            OxiaError::SessionDoesNotExist() => COxiaError::SessionDoesNotExist,
-            OxiaError::InternalRetryable() => COxiaError::InternalRetryable,
-            OxiaError::Cancelled() => COxiaError::Cancelled,
-            OxiaError::IllegalArgument(_) => COxiaError::IllegalArgument,
-            OxiaError::RequestTimeout() => COxiaError::RequestTimeout,
+            OxiaError::KeyNotFound => COxiaError::KeyNotFound,
+            OxiaError::UnexpectedVersionId => COxiaError::UnexpectedVersionId,
+            OxiaError::SessionExpired => COxiaError::SessionExpired,
+            OxiaError::RequestTooLarge => COxiaError::RequestTooLarge,
+            OxiaError::InvalidArgument(_) => COxiaError::InvalidArgument,
+            OxiaError::LeaderNotFound { .. } => COxiaError::LeaderNotFound,
+            OxiaError::NoShardForKey { .. } => COxiaError::NoShardForKey,
+            OxiaError::Disconnected(_) => COxiaError::Disconnected,
+            OxiaError::Timeout => COxiaError::Timeout,
+            OxiaError::Grpc { .. } => COxiaError::Grpc,
+            OxiaError::Decode(_) => COxiaError::Decode,
+            OxiaError::Closed => COxiaError::Closed,
+            // `OxiaError` is #[non_exhaustive]; map any future variant here.
+            _ => COxiaError::Other,
         }
     }
 }

--- a/oxia-client/src/batch.rs
+++ b/oxia-client/src/batch.rs
@@ -1,5 +1,4 @@
 use crate::errors::OxiaError;
-use crate::errors::OxiaError::UnexpectedStatus;
 use crate::operations::Operation;
 use crate::operations::ToProtobuf;
 use crate::operations::{
@@ -87,7 +86,9 @@ impl ReadBatch {
         let node = match self.shard_manager.get_leader(self.shard_id) {
             Some(node) => node,
             None => {
-                self.failure_inflight(OxiaError::ShardLeaderNotFound(self.shard_id));
+                self.failure_inflight(OxiaError::LeaderNotFound {
+                    shard: self.shard_id,
+                });
                 return;
             }
         };
@@ -110,7 +111,7 @@ impl ReadBatch {
                             self.failure_inflight(err)
                         }
                     }
-                    Err(err) => self.failure_inflight(UnexpectedStatus(err.to_string())),
+                    Err(err) => self.failure_inflight(OxiaError::from(err)),
                 }
             }
             Err(err) => self.failure_inflight(err),
@@ -129,14 +130,12 @@ impl ReadBatch {
                 // stream is closed
                 break;
             }
-            let read_response = next
-                .unwrap()
-                .map_err(|err| UnexpectedStatus(err.to_string()))?;
+            let read_response = next.unwrap().map_err(OxiaError::from)?;
             for get_response in read_response.gets {
                 let next_inflight = inflight_iter.next();
                 if next_inflight.is_none() {
-                    return Err(UnexpectedStatus(
-                        "bug! unexpected inflight response".to_string(),
+                    return Err(OxiaError::Decode(
+                        "server returned more get responses than requested".to_string(),
                     ));
                 }
                 let mut operation = next_inflight.unwrap();
@@ -230,7 +229,7 @@ impl WriteBatch {
                 for mut operation in self.put_inflight.drain(..) {
                     match put_responses.next() {
                         Some(put_response) => operation.complete(put_response),
-                        None => operation.complete_exception(UnexpectedStatus(
+                        None => operation.complete_exception(OxiaError::Decode(
                             "missing put response from server".to_string(),
                         )),
                     }
@@ -239,7 +238,7 @@ impl WriteBatch {
                 for mut operation in self.delete_inflight.drain(..) {
                     match delete_responses.next() {
                         Some(delete_response) => operation.complete(delete_response),
-                        None => operation.complete_exception(UnexpectedStatus(
+                        None => operation.complete_exception(OxiaError::Decode(
                             "missing delete response from server".to_string(),
                         )),
                     }
@@ -248,7 +247,7 @@ impl WriteBatch {
                 for mut operation in self.delete_range_inflight.drain(..) {
                     match delete_range_responses.next() {
                         Some(delete_range_response) => operation.complete(delete_range_response),
-                        None => operation.complete_exception(UnexpectedStatus(
+                        None => operation.complete_exception(OxiaError::Decode(
                             "missing delete_range response from server".to_string(),
                         )),
                     }

--- a/oxia-client/src/batch_manager.rs
+++ b/oxia-client/src/batch_manager.rs
@@ -1,6 +1,5 @@
 use crate::batch::{Batch, ReadBatch, WriteBatch};
 use crate::errors::OxiaError;
-use crate::errors::OxiaError::UnexpectedStatus;
 use crate::operations::Operation;
 use crate::provider_manager::ProviderManager;
 use crate::shard_manager::ShardManager;
@@ -90,9 +89,10 @@ impl BatchManager {
     }
 
     pub fn add(&self, operation: Operation) -> Result<(), OxiaError> {
-        self.tx
-            .send(operation)
-            .map_err(|err| UnexpectedStatus(err.to_string()))?;
+        // The batcher's receiver is only dropped when the batcher has been shut
+        // down, so a send failure means the client (or this shard's batcher) is
+        // gone.
+        self.tx.send(operation).map_err(|_| OxiaError::Closed)?;
         Ok(())
     }
 
@@ -102,7 +102,7 @@ impl BatchManager {
         if let Some(handle) = handle_guard.take() {
             handle
                 .await
-                .map_err(|err| UnexpectedStatus(err.to_string()))?;
+                .map_err(|err| OxiaError::Disconnected(err.to_string()))?;
         }
         Ok(())
     }

--- a/oxia-client/src/client.rs
+++ b/oxia-client/src/client.rs
@@ -1,10 +1,6 @@
 use crate::batch_manager::{BatchManager, Batcher};
 use crate::client_options::OxiaClientOptions;
 use crate::errors::OxiaError;
-use crate::errors::OxiaError::{
-    IllegalArgument, KeyLeaderNotFound, KeyNotFound, SessionDoesNotExist, UnexpectedStatus,
-    UnexpectedVersionId,
-};
 use crate::key;
 use crate::notification_manager::NotificationManager;
 use crate::operations::{
@@ -526,7 +522,9 @@ impl OxiaClient {
     ) -> Result<(i64, Arc<BatchManager>), OxiaError> {
         match self.inner.shard_manager.get_shard(key) {
             Some(shard_id) => self.get_or_init_batch_manager_with_shard(batcher, shard_id),
-            None => Err(KeyLeaderNotFound(key.to_string())),
+            None => Err(OxiaError::NoShardForKey {
+                key: key.to_string(),
+            }),
         }
     }
 
@@ -595,8 +593,8 @@ impl Client for OxiaClient {
         batch_manager.add(Operation::Put(operation))?;
         let put_response = tokio::time::timeout(self.request_timeout(), rx)
             .await
-            .map_err(|_| OxiaError::RequestTimeout())?
-            .map_err(|err| UnexpectedStatus(err.to_string()))??;
+            .map_err(|_| OxiaError::Timeout)?
+            .map_err(|err| OxiaError::Disconnected(err.to_string()))??;
         check_status(put_response.status)?;
         Ok(PutResult {
             key: put_response.key.unwrap_or(key.clone()),
@@ -624,8 +622,8 @@ impl Client for OxiaClient {
         batch_manager.add(Operation::Delete(operation))?;
         let response = tokio::time::timeout(self.request_timeout(), rx)
             .await
-            .map_err(|_| OxiaError::RequestTimeout())?
-            .map_err(|err| UnexpectedStatus(err.to_string()))??;
+            .map_err(|_| OxiaError::Timeout)?
+            .map_err(|err| OxiaError::Disconnected(err.to_string()))??;
 
         Ok(check_status(response.status)?)
     }
@@ -670,15 +668,15 @@ impl Client for OxiaClient {
             for result in all_results {
                 match result {
                     Ok(get_result) => results.push(get_result),
-                    Err(OxiaError::KeyNotFound()) => {
+                    Err(OxiaError::KeyNotFound) => {
                         // KeyNotFound from some shards is expected for non-partition queries
-                        last_error = Some(KeyNotFound());
+                        last_error = Some(OxiaError::KeyNotFound);
                     }
                     Err(err) => return Err(err),
                 }
             }
             if results.is_empty() {
-                return Err(last_error.unwrap_or(KeyNotFound()));
+                return Err(last_error.unwrap_or(OxiaError::KeyNotFound));
             }
             results.sort();
             let index = match operation.comparison_type {
@@ -714,7 +712,7 @@ impl Client for OxiaClient {
             let local_operation = list_operation.clone();
             let partition_key = local_operation.partition_key.clone().unwrap();
             return match self.inner.shard_manager.get_shard_leader(&partition_key) {
-                None => Err(KeyLeaderNotFound(partition_key)),
+                None => Err(OxiaError::NoShardForKey { key: partition_key }),
                 Some(leader) => {
                     list_from_single_shard(
                         leader,
@@ -770,7 +768,7 @@ impl Client for OxiaClient {
             let local_operation = operation.clone();
             let partition_key = local_operation.partition_key.clone().unwrap();
             return match self.inner.shard_manager.get_shard_leader(&partition_key) {
-                None => Err(KeyLeaderNotFound(partition_key)),
+                None => Err(OxiaError::NoShardForKey { key: partition_key }),
                 Some(leader) => {
                     range_scan_from_single_shard(
                         leader,
@@ -885,7 +883,7 @@ impl Client for OxiaClient {
         let mut manager_guard = self.inner.sequence_updates_manager.lock().await;
         let operation: GetSequenceUpdatesOperation = options.into();
         if operation.partition_key.is_none() {
-            return Err(IllegalArgument(
+            return Err(OxiaError::InvalidArgument(
                 "required option: partition_key".to_string(),
             ));
         }
@@ -905,7 +903,7 @@ impl Client for OxiaClient {
         let inner = match Arc::try_unwrap(self.inner) {
             Ok(inner) => inner,
             Err(arc) => {
-                return Err(UnexpectedStatus(format!(
+                return Err(OxiaError::InvalidArgument(format!(
                     "Cannot shutdown inner: {} other references exist",
                     Arc::strong_count(&arc)
                 )))
@@ -917,7 +915,7 @@ impl Client for OxiaClient {
             let manager = match Arc::try_unwrap(wb) {
                 Ok(inner) => inner,
                 Err(arc) => {
-                    return Err(UnexpectedStatus(format!(
+                    return Err(OxiaError::InvalidArgument(format!(
                         "Cannot shutdown write batch manager: {} other references exist",
                         Arc::strong_count(&arc)
                     )))
@@ -929,7 +927,7 @@ impl Client for OxiaClient {
             let manager = match Arc::try_unwrap(rb) {
                 Ok(inner) => inner,
                 Err(arc) => {
-                    return Err(UnexpectedStatus(format!(
+                    return Err(OxiaError::InvalidArgument(format!(
                         "Cannot shutdown read batch manager: {} other references exist",
                         Arc::strong_count(&arc)
                     )))
@@ -939,14 +937,14 @@ impl Client for OxiaClient {
         }
         while let Some(result) = joiner.join_next().await {
             result.map_err(|err| {
-                UnexpectedStatus(format!("batcher task failed to join: {}", err))
+                OxiaError::Disconnected(format!("batcher task failed to join: {}", err))
             })??;
         }
 
         for nm in match Arc::try_unwrap(inner.notification_managers) {
             Ok(wsm) => wsm,
             Err(arc) => {
-                return Err(UnexpectedStatus(format!(
+                return Err(OxiaError::InvalidArgument(format!(
                     "Cannot shutdown notification managers: {} other references exist",
                     Arc::strong_count(&arc)
                 )))
@@ -962,7 +960,7 @@ impl Client for OxiaClient {
         for nm in match Arc::try_unwrap(inner.sequence_updates_manager) {
             Ok(wsm) => wsm,
             Err(arc) => {
-                return Err(UnexpectedStatus(format!(
+                return Err(OxiaError::InvalidArgument(format!(
                     "Cannot shutdown sequence updates managers: {} other references exist",
                     Arc::strong_count(&arc)
                 )))
@@ -978,7 +976,7 @@ impl Client for OxiaClient {
         match Arc::try_unwrap(inner.write_stream_manager) {
             Ok(wsm) => wsm,
             Err(arc) => {
-                return Err(UnexpectedStatus(format!(
+                return Err(OxiaError::InvalidArgument(format!(
                     "Cannot shutdown write stream manager: {} other references exist",
                     Arc::strong_count(&arc)
                 )))
@@ -990,7 +988,7 @@ impl Client for OxiaClient {
         match Arc::try_unwrap(inner.session_manager) {
             Ok(sm) => sm,
             Err(arc) => {
-                return Err(UnexpectedStatus(format!(
+                return Err(OxiaError::InvalidArgument(format!(
                     "Cannot shutdown session manager: {} other references exist",
                     Arc::strong_count(&arc)
                 )));
@@ -1002,7 +1000,7 @@ impl Client for OxiaClient {
         match Arc::try_unwrap(inner.shard_manager) {
             Ok(sm) => sm,
             Err(arc) => {
-                return Err(UnexpectedStatus(format!(
+                return Err(OxiaError::InvalidArgument(format!(
                     "Cannot shutdown shard manager: {} other references exist",
                     Arc::strong_count(&arc)
                 )));
@@ -1014,7 +1012,7 @@ impl Client for OxiaClient {
         match Arc::try_unwrap(inner.provider_manager) {
             Ok(pm) => pm,
             Err(arc) => {
-                return Err(UnexpectedStatus(format!(
+                return Err(OxiaError::InvalidArgument(format!(
                     "Cannot shutdown provider manager: {} other references exist",
                     Arc::strong_count(&arc)
                 )))
@@ -1052,7 +1050,7 @@ async fn range_scan_from_single_shard(
                 }
             }
             Err(err) => {
-                return Err(UnexpectedStatus(err.to_string()));
+                return Err(OxiaError::from(err));
             }
         }
     }
@@ -1077,7 +1075,7 @@ async fn list_from_single_shard(
         match response {
             Ok(mut response) => keys.append(&mut response.keys),
             Err(err) => {
-                return Err(UnexpectedStatus(err.to_string()));
+                return Err(OxiaError::from(err));
             }
         }
     }
@@ -1095,8 +1093,8 @@ async fn delete_range_from_single_shard(
     batch_manager.add(Operation::DeleteRange(operation))?;
     let response = tokio::time::timeout(timeout, rx)
         .await
-        .map_err(|_| OxiaError::RequestTimeout())?
-        .map_err(|err| UnexpectedStatus(err.to_string()))??;
+        .map_err(|_| OxiaError::Timeout)?
+        .map_err(|err| OxiaError::Disconnected(err.to_string()))??;
     check_status(response.status)
 }
 
@@ -1112,8 +1110,8 @@ async fn get_from_single_shard(
     batch_manager.add(Operation::Get(operation))?;
     let get_response = tokio::time::timeout(timeout, rx)
         .await
-        .map_err(|_| OxiaError::RequestTimeout())?
-        .map_err(|err| UnexpectedStatus(err.to_string()))??;
+        .map_err(|_| OxiaError::Timeout)?
+        .map_err(|err| OxiaError::Disconnected(err.to_string()))??;
     check_status(get_response.status)?;
     Ok(GetResult {
         key: get_response.key.unwrap_or(extra_key),
@@ -1126,11 +1124,11 @@ fn check_status(status: i32) -> Result<(), OxiaError> {
     match Status::try_from(status) {
         Ok(status) => match status {
             Status::Ok => Ok(()),
-            Status::KeyNotFound => Err(KeyNotFound()),
-            Status::UnexpectedVersionId => Err(UnexpectedVersionId()),
-            Status::SessionDoesNotExist => Err(SessionDoesNotExist()),
+            Status::KeyNotFound => Err(OxiaError::KeyNotFound),
+            Status::UnexpectedVersionId => Err(OxiaError::UnexpectedVersionId),
+            Status::SessionDoesNotExist => Err(OxiaError::SessionExpired),
         },
-        Err(err) => Err(UnexpectedStatus(err.to_string())),
+        Err(err) => Err(OxiaError::Decode(format!("invalid status code: {err}"))),
     }
 }
 

--- a/oxia-client/src/errors.rs
+++ b/oxia-client/src/errors.rs
@@ -1,40 +1,174 @@
 use thiserror::Error;
 
+/// Errors returned by the Oxia client.
+///
+/// The variants fall into three groups:
+/// - **Semantic results** callers commonly match on ([`KeyNotFound`],
+///   [`UnexpectedVersionId`], [`SessionExpired`], [`RequestTooLarge`],
+///   [`InvalidArgument`]). These are never retryable.
+/// - **Transient failures** that the client's background loops (and, in a later
+///   phase, its operation-level retries) may retry: [`LeaderNotFound`],
+///   [`NoShardForKey`], [`Disconnected`], and some [`Grpc`] codes. See
+///   [`OxiaError::is_retryable`].
+/// - **Terminal failures**: [`Timeout`], [`Decode`], [`Closed`], and the
+///   remaining [`Grpc`] codes.
+///
+/// [`KeyNotFound`]: OxiaError::KeyNotFound
+/// [`UnexpectedVersionId`]: OxiaError::UnexpectedVersionId
+/// [`SessionExpired`]: OxiaError::SessionExpired
+/// [`RequestTooLarge`]: OxiaError::RequestTooLarge
+/// [`InvalidArgument`]: OxiaError::InvalidArgument
+/// [`LeaderNotFound`]: OxiaError::LeaderNotFound
+/// [`NoShardForKey`]: OxiaError::NoShardForKey
+/// [`Disconnected`]: OxiaError::Disconnected
+/// [`Grpc`]: OxiaError::Grpc
+/// [`Timeout`]: OxiaError::Timeout
+/// [`Decode`]: OxiaError::Decode
+/// [`Closed`]: OxiaError::Closed
 #[derive(Error, Debug, Clone)]
+#[non_exhaustive]
 pub enum OxiaError {
-    #[error("unexpected transport error: {0}")]
-    Transport(String),
-
-    #[error("unexpected grpc status: {0}")]
-    GrpcStatus(#[from] tonic::Status),
-
-    #[error("unexpected status: {0}")]
-    UnexpectedStatus(String),
-
-    #[error("shard leader not found.  shard={0}")]
-    ShardLeaderNotFound(i64),
-
-    #[error("key leader not found.  key={0}")]
-    KeyLeaderNotFound(String),
-
+    /// The requested key does not exist.
     #[error("key not found")]
-    KeyNotFound(),
+    KeyNotFound,
 
+    /// A conditional operation failed because the stored version did not match
+    /// the expected one.
     #[error("unexpected version id")]
-    UnexpectedVersionId(),
+    UnexpectedVersionId,
 
-    #[error("session does not exist")]
-    SessionDoesNotExist(),
+    /// The session backing an ephemeral record has expired or been closed.
+    #[error("session no longer exists")]
+    SessionExpired,
 
-    #[error("retryable")]
-    InternalRetryable(),
+    /// A single request, or a batch that cannot be split further, exceeds the
+    /// server's maximum message size.
+    #[error("request is too large")]
+    RequestTooLarge,
 
-    #[error("the operation has been cancelled")]
-    Cancelled(),
+    /// An option or argument passed to an operation was invalid.
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
 
-    #[error("illegal argument: {0}")]
-    IllegalArgument(String),
+    /// No leader is currently available for the shard (e.g. a leader election is
+    /// in progress). Retryable.
+    #[error("no leader available for shard {shard}")]
+    LeaderNotFound { shard: i64 },
 
-    #[error("request timeout")]
-    RequestTimeout(),
+    /// No shard currently owns the key, because shard assignments have not been
+    /// loaded yet or are momentarily incomplete. Retryable.
+    #[error("no shard owns key {key:?} (assignments not ready)")]
+    NoShardForKey { key: String },
+
+    /// The connection to a server was lost or could not be established, or an
+    /// in-flight request's worker went away. Retryable.
+    #[error("disconnected: {0}")]
+    Disconnected(String),
+
+    /// An operation did not complete before its deadline.
+    #[error("request timed out")]
+    Timeout,
+
+    /// The server returned a gRPC status. Whether it is retryable depends on the
+    /// code (see [`OxiaError::is_retryable`]).
+    #[error("grpc status {code:?}: {message}")]
+    Grpc {
+        /// The gRPC status code.
+        code: tonic::Code,
+        /// The gRPC status message.
+        message: String,
+    },
+
+    /// A server response could not be decoded — a required field was missing, or
+    /// the response did not match the request. Indicates a protocol mismatch or
+    /// a server bug.
+    #[error("failed to decode server response: {0}")]
+    Decode(String),
+
+    /// The client has been shut down and can no longer be used.
+    #[error("client is closed")]
+    Closed,
+}
+
+impl OxiaError {
+    /// Whether retrying the operation that produced this error might succeed.
+    ///
+    /// Mirrors the retryable set of the reference Go client: connection loss,
+    /// missing shard leaders / assignments, and the `UNAVAILABLE` / `ABORTED`
+    /// gRPC codes. Semantic results (e.g. [`KeyNotFound`](OxiaError::KeyNotFound))
+    /// and terminal failures are not retryable.
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            OxiaError::LeaderNotFound { .. }
+            | OxiaError::NoShardForKey { .. }
+            | OxiaError::Disconnected(_) => true,
+            OxiaError::Grpc { code, .. } => {
+                matches!(code, tonic::Code::Unavailable | tonic::Code::Aborted)
+            }
+            _ => false,
+        }
+    }
+}
+
+impl From<tonic::Status> for OxiaError {
+    fn from(status: tonic::Status) -> Self {
+        OxiaError::Grpc {
+            code: status.code(),
+            message: status.message().to_string(),
+        }
+    }
+}
+
+impl From<tonic::transport::Error> for OxiaError {
+    fn from(err: tonic::transport::Error) -> Self {
+        OxiaError::Disconnected(err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retryable_classification() {
+        let msg = String::new();
+        assert!(OxiaError::LeaderNotFound { shard: 1 }.is_retryable());
+        assert!(OxiaError::NoShardForKey { key: "k".into() }.is_retryable());
+        assert!(OxiaError::Disconnected("x".into()).is_retryable());
+        assert!(OxiaError::Grpc {
+            code: tonic::Code::Unavailable,
+            message: msg.clone(),
+        }
+        .is_retryable());
+        assert!(OxiaError::Grpc {
+            code: tonic::Code::Aborted,
+            message: msg.clone(),
+        }
+        .is_retryable());
+
+        assert!(!OxiaError::KeyNotFound.is_retryable());
+        assert!(!OxiaError::UnexpectedVersionId.is_retryable());
+        assert!(!OxiaError::SessionExpired.is_retryable());
+        assert!(!OxiaError::RequestTooLarge.is_retryable());
+        assert!(!OxiaError::Timeout.is_retryable());
+        assert!(!OxiaError::Closed.is_retryable());
+        assert!(!OxiaError::Grpc {
+            code: tonic::Code::NotFound,
+            message: msg,
+        }
+        .is_retryable());
+    }
+
+    #[test]
+    fn from_tonic_status_maps_to_grpc() {
+        let err = OxiaError::from(tonic::Status::unavailable("down"));
+        assert!(matches!(
+            err,
+            OxiaError::Grpc {
+                code: tonic::Code::Unavailable,
+                ..
+            }
+        ));
+        assert!(err.is_retryable());
+    }
 }

--- a/oxia-client/src/notification_manager.rs
+++ b/oxia-client/src/notification_manager.rs
@@ -1,6 +1,5 @@
 use crate::client::Notification;
 use crate::errors::OxiaError;
-use crate::errors::OxiaError::{ShardLeaderNotFound, UnexpectedStatus};
 use crate::oxia::NotificationsRequest;
 use crate::provider_manager::ProviderManager;
 use crate::shard_manager::ShardManager;
@@ -58,7 +57,7 @@ impl NotificationListener {
         if let Some(handle) = handle_guard.take() {
             handle
                 .await
-                .map_err(|err| UnexpectedStatus(err.to_string()))?;
+                .map_err(|err| OxiaError::Disconnected(err.to_string()))?;
         }
         Ok(())
     }
@@ -80,7 +79,11 @@ async fn start_notification_listener(
         let sender = sender.clone();
         async move {
             let mut provider = match shard_manager.get_leader(shard_id) {
-                None => return Err(Error::transient(ShardLeaderNotFound(shard_id))),
+                None => {
+                    return Err(Error::transient(OxiaError::LeaderNotFound {
+                        shard: shard_id,
+                    }))
+                }
                 Some(leader) => provider_manager
                     .get_provider(leader.service_address)
                     .await
@@ -92,7 +95,7 @@ async fn start_notification_listener(
                     start_offset_exclusive: Some(offset_ref.load(Ordering::Acquire)),
                 })
                 .await
-                .map_err(|err| Error::transient(UnexpectedStatus(err.to_string())))?
+                .map_err(|err| Error::transient(OxiaError::from(err)))?
                 .into_inner();
             loop {
                 tokio::select! {
@@ -102,10 +105,12 @@ async fn start_notification_listener(
                 },
                 message = streaming.next() => match message {
                         None => {
-                            return Err(Error::transient(UnexpectedStatus(String::from( "streaming has closed by server", )))); }
+                            return Err(Error::transient(OxiaError::Disconnected(
+                                "notification stream closed by server".to_string(),
+                            ))); }
                         Some(notification) => {
                             let batch = notification.map_err(|err| {
-                                Error::transient(UnexpectedStatus(err.to_string()))
+                                Error::transient(OxiaError::from(err))
                             })?;
                             offset_ref.store(batch.offset, Ordering::Release);
                             for entry in batch.notifications {

--- a/oxia-client/src/provider_manager.rs
+++ b/oxia-client/src/provider_manager.rs
@@ -1,5 +1,4 @@
 use crate::errors::OxiaError;
-use crate::errors::OxiaError::UnexpectedStatus;
 use crate::oxia::oxia_client_client::OxiaClientClient;
 use dashmap::DashMap;
 use std::sync::Arc;
@@ -18,9 +17,7 @@ impl ProviderManager {
         let once_cell = self.providers.entry(address.clone()).or_default();
         let client = once_cell
             .get_or_try_init(|| async {
-                let client = OxiaClientClient::connect(address)
-                    .await
-                    .map_err(|err| UnexpectedStatus(err.to_string()))?;
+                let client = OxiaClientClient::connect(address).await?;
                 Ok::<OxiaClientClient<Channel>, OxiaError>(client.clone())
             })
             .await?

--- a/oxia-client/src/sequence_updates_manager.rs
+++ b/oxia-client/src/sequence_updates_manager.rs
@@ -1,5 +1,4 @@
 use crate::errors::OxiaError;
-use crate::errors::OxiaError::{KeyLeaderNotFound, UnexpectedStatus};
 use crate::oxia::GetSequenceUpdatesRequest;
 use crate::provider_manager::ProviderManager;
 use crate::shard_manager::ShardManager;
@@ -46,7 +45,7 @@ impl SequenceUpdatesManager {
         if let Some(handle) = self.handle.lock().await.take() {
             handle
                 .await
-                .map_err(|err| UnexpectedStatus(err.to_string()))?;
+                .map_err(|err| OxiaError::Disconnected(err.to_string()))?;
         }
         Ok(())
     }
@@ -70,9 +69,11 @@ async fn start_listener(
         let shard_manager = shard_manager.clone();
         async move {
             match shard_manager.get_shard(&partition_key) {
-                None => Err(Error::transient(KeyLeaderNotFound(partition_key.clone()))),
+                None => Err(Error::transient(OxiaError::NoShardForKey {
+                    key: partition_key.clone(),
+                })),
                 Some(shard) => match shard_manager.get_leader(shard) {
-                    None => Err(Error::transient(KeyLeaderNotFound(partition_key.clone()))),
+                    None => Err(Error::transient(OxiaError::LeaderNotFound { shard })),
                     Some(leader) => {
                         let mut provider = provider_manager
                             .get_provider(leader.service_address)
@@ -84,7 +85,7 @@ async fn start_listener(
                                 key,
                             }))
                             .await
-                            .map_err(|err| Error::transient(UnexpectedStatus(err.to_string())))?
+                            .map_err(|err| Error::transient(OxiaError::from(err)))?
                             .into_inner();
                         loop {
                             tokio::select! {
@@ -96,13 +97,13 @@ async fn start_listener(
                                     match next_response {
                                     None => {
                                         info!("Sequence updates stream closed by server.");
-                                        return Err(Error::transient(UnexpectedStatus(
+                                        return Err(Error::transient(OxiaError::Disconnected(
                                             "sequence updates stream closed by server".to_string(),
                                         )));
                                     }
                                     Some(result) => {
                                         let response = result
-                                            .map_err(|err| Error::transient(UnexpectedStatus(err.to_string())))?;
+                                            .map_err(|err| Error::transient(OxiaError::from(err)))?;
                                         if sender.send(response.highest_sequence_key).await.is_err() {
                                             // Receiver dropped, stop listening
                                             return Ok(());

--- a/oxia-client/src/session_manager.rs
+++ b/oxia-client/src/session_manager.rs
@@ -1,5 +1,4 @@
 use crate::errors::OxiaError;
-use crate::errors::OxiaError::{SessionDoesNotExist, ShardLeaderNotFound, UnexpectedStatus};
 use crate::oxia::{CloseSessionRequest, CreateSessionRequest, SessionHeartbeat};
 use crate::provider_manager::ProviderManager;
 use crate::shard_manager::ShardManager;
@@ -85,7 +84,9 @@ async fn start_keep_alive(
         let local_context = context.clone();
         async move {
             match local_shard_manager.get_leader(shard_id) {
-                None => Err(Error::transient(ShardLeaderNotFound(shard_id))),
+                None => Err(Error::transient(OxiaError::LeaderNotFound {
+                    shard: shard_id,
+                })),
                 Some(leader) => {
                     let mut provider = local_provider_manager
                         .get_provider(leader.service_address)
@@ -105,9 +106,9 @@ async fn start_keep_alive(
                                     .map_err(|err| {
                                         if err.code() as i32 == CODE_SESSION_NOT_FOUND {
                                             info!("Session keep-alive exit due to session not found.");
-                                            return Error::permanent(SessionDoesNotExist());
+                                            return Error::permanent(OxiaError::SessionExpired);
                                         }
-                                        Error::transient(UnexpectedStatus(err.to_string()))
+                                        Error::transient(OxiaError::from(err))
                                     })?;
                             }
                         }
@@ -138,7 +139,7 @@ impl Session {
                     session_id: self.inner.id,
                 }))
                 .await
-                .map_err(|err| UnexpectedStatus(err.to_string()));
+                .map_err(OxiaError::from);
             if let Err(err) = result {
                 warn!(
                     "Failed to close session. shard_id={:?} session_id={:?} error={:?}",
@@ -154,7 +155,7 @@ impl Session {
         if let Some(handle) = guard.take() {
             handle
                 .await
-                .map_err(|err| UnexpectedStatus(err.to_string()))?
+                .map_err(|err| OxiaError::Disconnected(err.to_string()))?
         }
         Ok(())
     }
@@ -189,7 +190,7 @@ impl SessionManager {
         let session = session_cell
             .get_or_try_init(|| async {
                 match self.shard_manager.get_leader(shard_id) {
-                    None => Err(ShardLeaderNotFound(shard_id)),
+                    None => Err(OxiaError::LeaderNotFound { shard: shard_id }),
                     Some(node) => {
                         let mut provider = self
                             .provider_manager
@@ -202,7 +203,7 @@ impl SessionManager {
                                 client_identity: self.identity.clone(),
                             }))
                             .await
-                            .map_err(|err| UnexpectedStatus(err.to_string()))?;
+                            .map_err(OxiaError::from)?;
                         let session_id = response.into_inner().session_id;
                         Ok(Session::new(
                             shard_id,
@@ -227,7 +228,7 @@ impl SessionManager {
         }
         while let Some(result) = joiner.join_next().await {
             result.map_err(|err| {
-                UnexpectedStatus(format!("Session task failed to join: {}", err))
+                OxiaError::Disconnected(format!("Session task failed to join: {}", err))
             })??;
         }
         Ok(())

--- a/oxia-client/src/shard_manager.rs
+++ b/oxia-client/src/shard_manager.rs
@@ -1,6 +1,5 @@
 use crate::address::ensure_protocol;
 use crate::errors::OxiaError;
-use crate::errors::OxiaError::UnexpectedStatus;
 use crate::hash::shard_key_hash;
 use crate::oxia::shard_assignment::ShardBoundaries;
 use crate::oxia::{ShardAssignment, ShardAssignmentsRequest, ShardKeyRouter};
@@ -64,13 +63,13 @@ async fn start_assignments_listener(
                 .provider_manager
                 .get_provider(local_address)
                 .await
-                .map_err(|err| Error::transient(UnexpectedStatus(err.to_string())))?;
+                .map_err(Error::transient)?;
             let mut streaming = provider
                 .get_shard_assignments(ShardAssignmentsRequest {
                     namespace: ns.clone(),
                 })
                 .await
-                .map_err(|err| Error::transient(UnexpectedStatus(err.to_string())))?
+                .map_err(|err| Error::transient(OxiaError::from(err)))?
                 .into_inner();
             loop {
                 tokio::select! {
@@ -102,7 +101,7 @@ async fn start_assignments_listener(
                             }
                         }
                         Err(stream_status) => {
-                             return Err(Error::transient(UnexpectedStatus(stream_status.to_string())));
+                             return Err(Error::transient(OxiaError::from(stream_status)));
                         }
                     }
                     }
@@ -152,7 +151,7 @@ impl ShardManager {
         if let Some(handle) = handle_guard.take() {
             handle
                 .await
-                .map_err(|err| UnexpectedStatus(err.to_string()))?;
+                .map_err(|err| OxiaError::Disconnected(err.to_string()))?;
         }
         Ok(())
     }

--- a/oxia-client/src/write_stream.rs
+++ b/oxia-client/src/write_stream.rs
@@ -1,5 +1,4 @@
 use crate::errors::OxiaError;
-use crate::errors::OxiaError::UnexpectedStatus;
 use crate::oxia::{WriteRequest, WriteResponse};
 use log::{info, warn};
 use std::collections::VecDeque;
@@ -45,7 +44,9 @@ impl WriteStream {
     pub(crate) async fn send_defer(&self, request: WriteRequest) -> Result<(), OxiaError> {
         let mut inner_guard = self.inner.lock().await;
         if !inner_guard.alive {
-            return Err(UnexpectedStatus("write stream is closed".to_string()));
+            return Err(OxiaError::Disconnected(
+                "write stream is closed".to_string(),
+            ));
         }
         let (tx, rx) = oneshot::channel();
         let inflight = Inflight { future: tx };
@@ -53,7 +54,7 @@ impl WriteStream {
         if let Err(err) = inner_guard.tx.send(request) {
             inner_guard.alive = false;
             inner_guard.fail_inflight();
-            return Err(UnexpectedStatus(err.to_string()));
+            return Err(OxiaError::Disconnected(err.to_string()));
         }
         drop(inner_guard);
         let mut guard = self.defer_response.lock().await;
@@ -68,7 +69,9 @@ impl WriteStream {
     pub(crate) async fn send(&self, request: WriteRequest) -> Result<WriteResponse, OxiaError> {
         let mut inner_guard = self.inner.lock().await;
         if !inner_guard.alive {
-            return Err(UnexpectedStatus("write stream is closed".to_string()));
+            return Err(OxiaError::Disconnected(
+                "write stream is closed".to_string(),
+            ));
         }
         let (tx, rx) = oneshot::channel();
         let inflight = Inflight { future: tx };
@@ -76,10 +79,11 @@ impl WriteStream {
         if let Err(err) = inner_guard.tx.send(request) {
             inner_guard.alive = false;
             inner_guard.fail_inflight();
-            return Err(UnexpectedStatus(err.to_string()));
+            return Err(OxiaError::Disconnected(err.to_string()));
         }
         drop(inner_guard);
-        rx.await.map_err(|err| UnexpectedStatus(err.to_string()))
+        rx.await
+            .map_err(|err| OxiaError::Disconnected(err.to_string()))
     }
 
     pub(crate) async fn get_defer_response(&self) -> Option<Result<WriteResponse, OxiaError>> {
@@ -90,7 +94,7 @@ impl WriteStream {
             option
                 .unwrap()
                 .await
-                .map_err(|err| UnexpectedStatus(err.to_string())),
+                .map_err(|err| OxiaError::Disconnected(err.to_string())),
         )
     }
 
@@ -124,7 +128,7 @@ impl WriteStream {
         if let Some(handle) = guard.take() {
             handle
                 .await
-                .map_err(|err| UnexpectedStatus(err.to_string()))?
+                .map_err(|err| OxiaError::Disconnected(err.to_string()))?
         }
         Ok(())
     }

--- a/oxia-client/src/write_stream_manager.rs
+++ b/oxia-client/src/write_stream_manager.rs
@@ -1,5 +1,4 @@
 use crate::errors::OxiaError;
-use crate::errors::OxiaError::{InternalRetryable, UnexpectedStatus};
 use crate::oxia::{WriteRequest, WriteResponse};
 use crate::provider_manager::ProviderManager;
 use crate::shard_manager::ShardManager;
@@ -26,19 +25,19 @@ impl WriteStreamManager {
     pub async fn write(&self, request: WriteRequest) -> Result<WriteResponse, OxiaError> {
         // todo: make request Rc
         loop {
-            match self.write0(request.clone()).await {
-                Ok(response) => return Ok(response),
-                Err(InternalRetryable()) => continue,
-                Err(err) => return Err(err),
+            // `write0` returns Ok(None) when the cached stream was found dead and
+            // torn down; loop to retry with a freshly created stream.
+            if let Some(response) = self.write0(request.clone()).await? {
+                return Ok(response);
             }
         }
     }
 
-    async fn write0(&self, request: WriteRequest) -> Result<WriteResponse, OxiaError> {
+    async fn write0(&self, request: WriteRequest) -> Result<Option<WriteResponse>, OxiaError> {
         let shard_id = request.shard.unwrap();
         let option = self.shard_manager.get_leader(shard_id);
         if option.is_none() {
-            return Err(OxiaError::ShardLeaderNotFound(shard_id));
+            return Err(OxiaError::LeaderNotFound { shard: shard_id });
         }
         let defer_init = || async {
             let mut provider = self
@@ -75,12 +74,12 @@ impl WriteStreamManager {
             if let Some(stream) = cell.take() {
                 stream.shutdown().await?;
             }
-            return Err(InternalRetryable());
+            return Ok(None);
         }
         if initialized {
-            return w_stream.send(request).await;
+            return w_stream.send(request).await.map(Some);
         }
-        w_stream.get_defer_response().await.unwrap()
+        Ok(Some(w_stream.get_defer_response().await.unwrap()?))
     }
 
     pub async fn shutdown(self) -> Result<(), OxiaError> {
@@ -94,8 +93,8 @@ impl WriteStreamManager {
         }
         while let Some(result) = joiner.join_next().await {
             result.map_err(|err| {
-                UnexpectedStatus(format!(
-                    "write stream nanager background task failed to join: {}",
+                OxiaError::Disconnected(format!(
+                    "write stream manager background task failed to join: {}",
                     err
                 ))
             })??;

--- a/oxia-client/tests/integration_tests.rs
+++ b/oxia-client/tests/integration_tests.rs
@@ -104,7 +104,7 @@ async fn test_delete() {
     client.delete("test/del".to_string()).await.unwrap();
 
     let result = client.get("test/del".to_string()).await;
-    assert!(matches!(result, Err(OxiaError::KeyNotFound())));
+    assert!(matches!(result, Err(OxiaError::KeyNotFound)));
 
     client.shutdown().await.unwrap();
 }
@@ -115,7 +115,7 @@ async fn test_get_nonexistent() {
     let client = new_client(&address).await;
 
     let result = client.get("nonexistent/key".to_string()).await;
-    assert!(matches!(result, Err(OxiaError::KeyNotFound())));
+    assert!(matches!(result, Err(OxiaError::KeyNotFound)));
 
     client.shutdown().await.unwrap();
 }
@@ -261,7 +261,7 @@ async fn test_expected_version_id() {
             vec![PutOption::ExpectVersionId(r1.version.version_id)],
         )
         .await;
-    assert!(matches!(err, Err(OxiaError::UnexpectedVersionId())));
+    assert!(matches!(err, Err(OxiaError::UnexpectedVersionId)));
 
     client
         .delete_range("ver/".to_string(), "ver/~".to_string())
@@ -293,7 +293,7 @@ async fn test_expected_record_not_exists() {
             vec![PutOption::ExpectedRecordNotExists()],
         )
         .await;
-    assert!(matches!(err, Err(OxiaError::UnexpectedVersionId())));
+    assert!(matches!(err, Err(OxiaError::UnexpectedVersionId)));
 
     client
         .delete_range("new/".to_string(), "new/~".to_string())
@@ -319,7 +319,7 @@ async fn test_delete_with_expected_version() {
             vec![DeleteOption::ExpectVersionId(999)],
         )
         .await;
-    assert!(matches!(err, Err(OxiaError::UnexpectedVersionId())));
+    assert!(matches!(err, Err(OxiaError::UnexpectedVersionId)));
 
     // Delete with correct version should succeed
     client
@@ -331,7 +331,7 @@ async fn test_delete_with_expected_version() {
         .unwrap();
 
     let get = client.get("delver/key".to_string()).await;
-    assert!(matches!(get, Err(OxiaError::KeyNotFound())));
+    assert!(matches!(get, Err(OxiaError::KeyNotFound)));
 
     client.shutdown().await.unwrap();
 }
@@ -476,7 +476,7 @@ async fn test_ephemeral_keys() {
     for attempt in 0..10 {
         tokio::time::sleep(Duration::from_millis(500 * (attempt + 1))).await;
         let result = client2.get("eph/key1".to_string()).await;
-        if matches!(result, Err(OxiaError::KeyNotFound())) {
+        if matches!(result, Err(OxiaError::KeyNotFound)) {
             found_deleted = true;
             break;
         }
@@ -964,7 +964,7 @@ async fn test_delete_nonexistent_key() {
     // Deleting a key that doesn't exist should succeed (idempotent)
     let result = client.delete("nonexistent/key123".to_string()).await;
     // Oxia returns KeyNotFound when deleting non-existent keys
-    assert!(result.is_ok() || matches!(result, Err(OxiaError::KeyNotFound())));
+    assert!(result.is_ok() || matches!(result, Err(OxiaError::KeyNotFound)));
 
     client.shutdown().await.unwrap();
 }
@@ -1014,7 +1014,7 @@ async fn test_sequential_operations() {
 
     // Verify deleted
     let get3 = client.get("seq-ops/key".to_string()).await;
-    assert!(matches!(get3, Err(OxiaError::KeyNotFound())));
+    assert!(matches!(get3, Err(OxiaError::KeyNotFound)));
 
     client.shutdown().await.unwrap();
 }
@@ -1708,7 +1708,7 @@ async fn test_concurrent_cas_conflict() {
 
     assert_eq!(successes.len(), 1, "Exactly one CAS should succeed");
     assert_eq!(failures.len(), 1, "Exactly one CAS should fail");
-    assert!(matches!(failures[0], Err(OxiaError::UnexpectedVersionId())));
+    assert!(matches!(failures[0], Err(OxiaError::UnexpectedVersionId)));
 
     client
         .delete_range("conflict/".to_string(), "conflict/~".to_string())


### PR DESCRIPTION
The foundation for the rest of Phase 1 (op-level retries, leader hints, session recreation, byte-limit batching): a structured error type the client can *branch* on, replacing the stringly `UnexpectedStatus(String)` catch-all.

## The new `OxiaError`

`#[non_exhaustive]`, with three groups:

| Group | Variants |
|---|---|
| Semantic (callers match; never retryable) | `KeyNotFound`, `UnexpectedVersionId`, `SessionExpired`, `RequestTooLarge`, `InvalidArgument(String)` |
| Transient (retryable) | `LeaderNotFound { shard }`, `NoShardForKey { key }`, `Disconnected(String)`, and some `Grpc` codes |
| Terminal | `Timeout`, `Grpc { code, message }`, `Decode(String)`, `Closed` |

Plus `OxiaError::is_retryable()`, mirroring the Go client's retryable set (`Disconnected`, `LeaderNotFound`, `NoShardForKey`, gRPC `Unavailable`/`Aborted`).

## What changed at the ~90 call sites

- **`UnexpectedStatus(String)` is gone** (was 65 sites). gRPC statuses and transport errors now convert through `From<tonic::Status>` / `From<tonic::transport::Error>`, preserving the gRPC **code** instead of flattening to a string.
- Missing/extra responses and undecodable status ints → `Decode`; connection/worker/task loss → `Disconnected`; the shutdown `Arc::try_unwrap` "references exist" failures → `InvalidArgument`.
- The old `ShardLeaderNotFound(i64)` / `KeyLeaderNotFound(String)` split becomes `LeaderNotFound { shard }` (known shard, no leader) vs `NoShardForKey { key }` (routing not ready).
- The write-stream retry that abused an error variant (`InternalRetryable`) is replaced by an `Ok(None)` return from `write0` — no control-flow-via-error.
- Removed dead variants (`Transport`, `Cancelled`, `GrpcStatus` `#[from]`).

## Notes for review

- `RequestTooLarge` is defined here but not yet *produced* — the byte-limit batching (P1-9) will return it. Wiring the variant now keeps that change small.
- `Grpc { code: tonic::Code, .. }` intentionally exposes `tonic::Code` (small, stable enum, matches how Go surfaces gRPC codes). If we later want to fully hide `tonic` from the public API (P2-1), it can be wrapped then.
- The FFI crate is frozen but must compile: its `COxiaError` enum, `From` mapping (with a `_ => Other` arm for the now-`#[non_exhaustive]` source), and the C header are updated.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean. **17** unit tests (incl. new `retryable_classification` and `from_tonic_status_maps_to_grpc`), **45** integration, **2** interop — all pass against `oxia/oxia:main`. Behavior is unchanged; this is a type-level refactor.