### PR TITLE
refactor: replace unmaintained backoff crate with internal retry loop (P1-2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,20 +110,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "futures-core",
- "getrandom 0.2.16",
- "instant",
- "pin-project-lite",
- "rand",
- "tokio",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,15 +904,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "io-uring"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,7 +1093,6 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 name = "oxia-client"
 version = "0.0.2"
 dependencies = [
- "backoff",
  "dashmap",
  "log",
  "prost",
@@ -1251,15 +1227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,36 +1311,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -2604,26 +2541,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-backoff = { version = "0.4.0", features = ["tokio"] }
 tonic = "0.13"
 prost = "0.13"
 tokio = { version = "1.47.0", features = ["rt-multi-thread", "macros"] }

--- a/oxia-client/Cargo.toml
+++ b/oxia-client/Cargo.toml
@@ -12,7 +12,6 @@ homepage = "https://github.com/oxia-db/oxia-client-rust"
 name = "oxia"
 
 [dependencies]
-backoff = { workspace = true }
 tonic = { workspace = true }
 prost = { workspace = true }
 tokio = { workspace = true }

--- a/oxia-client/src/lib.rs
+++ b/oxia-client/src/lib.rs
@@ -11,6 +11,7 @@ mod key;
 mod notification_manager;
 mod operations;
 mod provider_manager;
+mod retry;
 mod sequence_updates_manager;
 mod session_manager;
 mod shard_manager;

--- a/oxia-client/src/notification_manager.rs
+++ b/oxia-client/src/notification_manager.rs
@@ -2,10 +2,10 @@ use crate::client::Notification;
 use crate::errors::OxiaError;
 use crate::oxia::NotificationsRequest;
 use crate::provider_manager::ProviderManager;
+use crate::retry::{retry_until_cancelled, RetryError};
 use crate::shard_manager::ShardManager;
-use backoff::{Error, ExponentialBackoff};
 use dashmap::DashMap;
-use log::{info, warn};
+use log::info;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 use task::JoinHandle;
@@ -80,14 +80,14 @@ async fn start_notification_listener(
         async move {
             let mut provider = match shard_manager.get_leader(shard_id) {
                 None => {
-                    return Err(Error::transient(OxiaError::LeaderNotFound {
+                    return Err(RetryError::transient(OxiaError::LeaderNotFound {
                         shard: shard_id,
                     }))
                 }
                 Some(leader) => provider_manager
                     .get_provider(leader.service_address)
                     .await
-                    .map_err(Error::transient)?,
+                    .map_err(RetryError::transient)?,
             };
             let mut streaming = provider
                 .get_notifications(NotificationsRequest {
@@ -95,7 +95,7 @@ async fn start_notification_listener(
                     start_offset_exclusive: Some(offset_ref.load(Ordering::Acquire)),
                 })
                 .await
-                .map_err(|err| Error::transient(OxiaError::from(err)))?
+                .map_err(|err| RetryError::transient(OxiaError::from(err)))?
                 .into_inner();
             loop {
                 tokio::select! {
@@ -105,12 +105,12 @@ async fn start_notification_listener(
                 },
                 message = streaming.next() => match message {
                         None => {
-                            return Err(Error::transient(OxiaError::Disconnected(
+                            return Err(RetryError::transient(OxiaError::Disconnected(
                                 "notification stream closed by server".to_string(),
                             ))); }
                         Some(notification) => {
                             let batch = notification.map_err(|err| {
-                                Error::transient(OxiaError::from(err))
+                                RetryError::transient(OxiaError::from(err))
                             })?;
                             offset_ref.store(batch.offset, Ordering::Release);
                             for entry in batch.notifications {
@@ -126,14 +126,7 @@ async fn start_notification_listener(
             Ok(())
         }
     };
-    let notify = |err, duration| {
-        warn!(
-            "Transient failure when listen notification. error: {:?} retry-after: {:?}.",
-            err, duration
-        );
-    };
-    let backoff = ExponentialBackoff::default();
-    _ = backoff::future::retry_notify(backoff, defer, notify).await;
+    retry_until_cancelled(&passing_context, "notifications", defer).await;
 }
 
 pub struct NotificationManager {

--- a/oxia-client/src/retry.rs
+++ b/oxia-client/src/retry.rs
@@ -1,0 +1,142 @@
+//! Retry loop for the client's long-running background tasks (shard-assignment
+//! watcher, session keep-alive, notification and sequence-update listeners).
+//!
+//! This replaces the unmaintained `backoff` crate. Unlike `backoff`'s default
+//! policy, there is **no** maximum elapsed time: a background loop retries until
+//! its [`CancellationToken`] is cancelled, so a transient outage never silently
+//! kills the loop. The delay resets after any attempt that ran long enough to
+//! look healthy, so a stream that worked for a while before a hiccup reconnects
+//! promptly instead of waiting out a maxed-out backoff.
+
+use crate::errors::OxiaError;
+use log::warn;
+use std::future::Future;
+use std::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
+
+const INITIAL_DELAY: Duration = Duration::from_millis(100);
+const MAX_DELAY: Duration = Duration::from_secs(30);
+/// An attempt that ran at least this long is treated as progress and resets the
+/// backoff, so long-lived streams reconnect quickly after an occasional error.
+const RESET_AFTER: Duration = Duration::from_secs(10);
+
+/// The failure mode of a single attempt of a retried operation.
+pub(crate) enum RetryError {
+    /// A transient failure; retry after a backoff delay.
+    Transient(OxiaError),
+    /// A permanent failure; stop the loop without retrying.
+    Fatal(OxiaError),
+}
+
+impl RetryError {
+    /// Marks `err` as transient (will be retried). Usable as a `map_err` fn.
+    pub(crate) fn transient(err: OxiaError) -> Self {
+        RetryError::Transient(err)
+    }
+
+    /// Marks `err` as permanent (stops the loop). Usable as a `map_err` fn.
+    pub(crate) fn fatal(err: OxiaError) -> Self {
+        RetryError::Fatal(err)
+    }
+}
+
+struct Backoff {
+    current: Duration,
+}
+
+impl Backoff {
+    fn new() -> Self {
+        Backoff {
+            current: INITIAL_DELAY,
+        }
+    }
+
+    fn next_delay(&mut self) -> Duration {
+        let delay = self.current;
+        self.current = (self.current * 2).min(MAX_DELAY);
+        delay
+    }
+
+    fn reset(&mut self) {
+        self.current = INITIAL_DELAY;
+    }
+}
+
+/// Runs `op` repeatedly until it returns `Ok(())` (finished gracefully) or a
+/// [`RetryError::Fatal`], or `token` is cancelled.
+///
+/// [`RetryError::Transient`] results are retried with unbounded exponential
+/// backoff. Cancellation interrupts the delay between attempts; the operation
+/// itself is expected to observe `token` (typically via `tokio::select!`) to
+/// interrupt a live attempt.
+pub(crate) async fn retry_until_cancelled<F, Fut>(token: &CancellationToken, what: &str, mut op: F)
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<(), RetryError>>,
+{
+    let mut backoff = Backoff::new();
+    loop {
+        let started = Instant::now();
+        let result = op().await;
+        let healthy = started.elapsed() >= RESET_AFTER;
+        match result {
+            Ok(()) => return,
+            Err(RetryError::Fatal(err)) => {
+                warn!("Background task '{what}' stopped permanently: {err}");
+                return;
+            }
+            Err(RetryError::Transient(err)) => {
+                if healthy {
+                    backoff.reset();
+                }
+                let delay = backoff.next_delay();
+                warn!("Background task '{what}' failed, retrying in {delay:?}: {err}");
+                tokio::select! {
+                    _ = token.cancelled() => return,
+                    _ = tokio::time::sleep(delay) => {}
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_grows_caps_and_resets() {
+        let mut b = Backoff::new();
+        assert_eq!(b.next_delay(), Duration::from_millis(100));
+        assert_eq!(b.next_delay(), Duration::from_millis(200));
+        assert_eq!(b.next_delay(), Duration::from_millis(400));
+        // Keep growing until it saturates at MAX_DELAY.
+        for _ in 0..20 {
+            b.next_delay();
+        }
+        assert_eq!(b.next_delay(), MAX_DELAY);
+        b.reset();
+        assert_eq!(b.next_delay(), Duration::from_millis(100));
+    }
+
+    #[tokio::test]
+    async fn stops_on_cancellation_during_delay() {
+        let token = CancellationToken::new();
+        token.cancel();
+        // Every attempt fails transiently; with the token already cancelled the
+        // loop must return instead of retrying forever.
+        retry_until_cancelled(&token, "test", || async {
+            Err(RetryError::transient(OxiaError::Timeout))
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn stops_on_fatal() {
+        let token = CancellationToken::new();
+        retry_until_cancelled(&token, "test", || async {
+            Err(RetryError::fatal(OxiaError::SessionExpired))
+        })
+        .await;
+    }
+}

--- a/oxia-client/src/sequence_updates_manager.rs
+++ b/oxia-client/src/sequence_updates_manager.rs
@@ -1,9 +1,9 @@
 use crate::errors::OxiaError;
 use crate::oxia::GetSequenceUpdatesRequest;
 use crate::provider_manager::ProviderManager;
+use crate::retry::{retry_until_cancelled, RetryError};
 use crate::shard_manager::ShardManager;
-use backoff::{Error, ExponentialBackoff};
-use log::{info, warn};
+use log::info;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::Mutex;
@@ -69,23 +69,23 @@ async fn start_listener(
         let shard_manager = shard_manager.clone();
         async move {
             match shard_manager.get_shard(&partition_key) {
-                None => Err(Error::transient(OxiaError::NoShardForKey {
+                None => Err(RetryError::transient(OxiaError::NoShardForKey {
                     key: partition_key.clone(),
                 })),
                 Some(shard) => match shard_manager.get_leader(shard) {
-                    None => Err(Error::transient(OxiaError::LeaderNotFound { shard })),
+                    None => Err(RetryError::transient(OxiaError::LeaderNotFound { shard })),
                     Some(leader) => {
                         let mut provider = provider_manager
                             .get_provider(leader.service_address)
                             .await
-                            .map_err(Error::transient)?;
+                            .map_err(RetryError::transient)?;
                         let mut streaming = provider
                             .get_sequence_updates(Request::new(GetSequenceUpdatesRequest {
                                 shard,
                                 key,
                             }))
                             .await
-                            .map_err(|err| Error::transient(OxiaError::from(err)))?
+                            .map_err(|err| RetryError::transient(OxiaError::from(err)))?
                             .into_inner();
                         loop {
                             tokio::select! {
@@ -97,13 +97,13 @@ async fn start_listener(
                                     match next_response {
                                     None => {
                                         info!("Sequence updates stream closed by server.");
-                                        return Err(Error::transient(OxiaError::Disconnected(
+                                        return Err(RetryError::transient(OxiaError::Disconnected(
                                             "sequence updates stream closed by server".to_string(),
                                         )));
                                     }
                                     Some(result) => {
                                         let response = result
-                                            .map_err(|err| Error::transient(OxiaError::from(err)))?;
+                                            .map_err(|err| RetryError::transient(OxiaError::from(err)))?;
                                         if sender.send(response.highest_sequence_key).await.is_err() {
                                             // Receiver dropped, stop listening
                                             return Ok(());
@@ -117,11 +117,5 @@ async fn start_listener(
             }
         }
     };
-    let _ = backoff::future::retry_notify(ExponentialBackoff::default(), defer, |err, duration| {
-        warn!(
-            "Transient failure when listen sequence update. error: {:?} retry-after: {:?}.",
-            err, duration
-        );
-    })
-    .await;
+    retry_until_cancelled(&context, "sequence-updates", defer).await;
 }

--- a/oxia-client/src/session_manager.rs
+++ b/oxia-client/src/session_manager.rs
@@ -1,9 +1,9 @@
 use crate::errors::OxiaError;
 use crate::oxia::{CloseSessionRequest, CreateSessionRequest, SessionHeartbeat};
 use crate::provider_manager::ProviderManager;
+use crate::retry::{retry_until_cancelled, RetryError};
 use crate::shard_manager::ShardManager;
 use crate::status::CODE_SESSION_NOT_FOUND;
-use backoff::{Error, ExponentialBackoff};
 use dashmap::DashMap;
 use log::{info, warn};
 use std::sync::Arc;
@@ -84,14 +84,14 @@ async fn start_keep_alive(
         let local_context = context.clone();
         async move {
             match local_shard_manager.get_leader(shard_id) {
-                None => Err(Error::transient(OxiaError::LeaderNotFound {
+                None => Err(RetryError::transient(OxiaError::LeaderNotFound {
                     shard: shard_id,
                 })),
                 Some(leader) => {
                     let mut provider = local_provider_manager
                         .get_provider(leader.service_address)
                         .await
-                        .map_err(Error::transient)?;
+                        .map_err(RetryError::transient)?;
                     let mut ticker = interval(heartbeat_interval);
                     loop {
                         tokio::select! {
@@ -106,9 +106,9 @@ async fn start_keep_alive(
                                     .map_err(|err| {
                                         if err.code() as i32 == CODE_SESSION_NOT_FOUND {
                                             info!("Session keep-alive exit due to session not found.");
-                                            return Error::permanent(OxiaError::SessionExpired);
+                                            return RetryError::fatal(OxiaError::SessionExpired);
                                         }
-                                        Error::transient(OxiaError::from(err))
+                                        RetryError::transient(OxiaError::from(err))
                                     })?;
                             }
                         }
@@ -117,14 +117,7 @@ async fn start_keep_alive(
             }
         }
     };
-    let backoff = ExponentialBackoff::default();
-    let _ = backoff::future::retry_notify(backoff, op_defer, |err, duration| {
-        warn!(
-            "Transient failure when session keep-alive. error: {:?} retry-after: {:?}.",
-            err, duration
-        )
-    })
-    .await;
+    retry_until_cancelled(&context, "session-keep-alive", op_defer).await;
 }
 
 impl Session {

--- a/oxia-client/src/shard_manager.rs
+++ b/oxia-client/src/shard_manager.rs
@@ -4,9 +4,9 @@ use crate::hash::shard_key_hash;
 use crate::oxia::shard_assignment::ShardBoundaries;
 use crate::oxia::{ShardAssignment, ShardAssignmentsRequest, ShardKeyRouter};
 use crate::provider_manager::ProviderManager;
-use backoff::{Error, ExponentialBackoff};
+use crate::retry::{retry_until_cancelled, RetryError};
 use dashmap::DashMap;
-use log::{info, warn};
+use log::info;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
@@ -63,13 +63,13 @@ async fn start_assignments_listener(
                 .provider_manager
                 .get_provider(local_address)
                 .await
-                .map_err(Error::transient)?;
+                .map_err(RetryError::transient)?;
             let mut streaming = provider
                 .get_shard_assignments(ShardAssignmentsRequest {
                     namespace: ns.clone(),
                 })
                 .await
-                .map_err(|err| Error::transient(OxiaError::from(err)))?
+                .map_err(|err| RetryError::transient(OxiaError::from(err)))?
                 .into_inner();
             loop {
                 tokio::select! {
@@ -101,7 +101,7 @@ async fn start_assignments_listener(
                             }
                         }
                         Err(stream_status) => {
-                             return Err(Error::transient(OxiaError::from(stream_status)));
+                             return Err(RetryError::transient(OxiaError::from(stream_status)));
                         }
                     }
                     }
@@ -109,14 +109,7 @@ async fn start_assignments_listener(
             }
         }
     };
-    let backoff = ExponentialBackoff::default();
-    let _ = backoff::future::retry_notify(backoff, op_defer, |err, duration| {
-        warn!(
-            "Transient failure receiving shard assignments. error: {:?} retry-after: {:?}.",
-            err, duration
-        )
-    })
-    .await;
+    retry_until_cancelled(&context, "shard-assignments", op_defer).await;
 }
 
 impl ShardManager {


### PR DESCRIPTION
Removes the last dependency on the **unmaintained `backoff` crate** (0.4.0, last released 2021, RUSTSEC-flagged) and fixes the "background loops die after ~15 min" class of bug in one move.

## Why

The four background loops used `backoff::ExponentialBackoff::default()`, which:
- has a **15-minute `max_elapsed_time`** → a prolonged outage made `retry_notify` give up and the loop's task exit silently, leaving stale routing or a dead session **forever**;
- **never reset** the delay across a long-healthy stream (the op only returns `Ok` on cancel), so a stream that worked for hours then hiccupped retried with a maxed-out delay;
- didn't interrupt its internal delay on **cancellation**.

## What

New `oxia-client/src/retry.rs` — `retry_until_cancelled(token, what, op)`:
- **unbounded** exponential backoff (100 ms → 30 s cap); never gives up on time;
- stops only on `Ok(())` (graceful), `RetryError::Fatal`, or **token cancellation**;
- **resets** the delay after any attempt that ran ≥ 10 s (healthy stream → prompt reconnect);
- **cancellation-bound**: `tokio::select!` cancels the inter-attempt delay, and each op still observes the token to interrupt a live attempt.

The four loops (shard-assignment watcher, session keep-alive, notification listener, sequence-update listener) now return `Result<(), RetryError>`. `RetryError::transient` / `RetryError::fatal` map **1:1** onto the old `backoff::Error::transient` / `permanent`, so the transient-vs-permanent classification per loop is unchanged — this is a mechanism swap. `backoff` is removed from both manifests and the lockfile.

## Scope note

The shard-assignment watcher **still stops on a graceful stream close** (a coordinator restart) — that's preserved here and is the subject of **P1-4** (infinite watch retry). This PR is only the retry *mechanism*.

## Verification

`fmt` + `clippy --workspace --all-targets -D warnings` clean. **20** unit tests (incl. 3 new: backoff growth/cap/reset, stop-on-cancel, stop-on-fatal), **45** integration, **2** interop — all green against `oxia/oxia:main`. The integration suite exercises every converted loop (ephemeral keys → keep-alive, notifications, sequence updates, and shard assignments on every connect).