### PR TITLE
refactor: harden shard manager — fail-fast init, resilient watch, atomic routing (P1-3/4/5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,12 @@ jobs:
       - name: Build
         run: cargo build --workspace
 
+      # The dockerized integration tests each start a container and, on a cold
+      # runner, would otherwise all pull this image at once — concurrent pulls of
+      # the same image race in the Docker client ("bytes remaining on stream").
+      # Pull it once up front so the tests find it already present.
+      - name: Pre-pull Oxia test image
+        run: docker pull oxia/oxia:main
+
       - name: Run tests
         run: cargo test --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,6 +1102,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 name = "oxia-client"
 version = "0.0.2"
 dependencies = [
+ "arc-swap",
  "dashmap",
  "log",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ dashmap = "6.1.0"
 xxhash-rust = { version = "0.8.5", features = ["xxh3"] }
 uuid = { version = "1.7", features = ["v4"] }
 tokio-util = "0.7"
+arc-swap = "1.7"
 log = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/oxia-client/Cargo.toml
+++ b/oxia-client/Cargo.toml
@@ -20,6 +20,7 @@ dashmap = { workspace = true }
 xxhash-rust = { workspace = true }
 uuid = { workspace = true }
 tokio-util = { workspace = true }
+arc-swap = { workspace = true }
 log = { workspace = true }
 
 [dev-dependencies]

--- a/oxia-client/src/client.rs
+++ b/oxia-client/src/client.rs
@@ -355,6 +355,7 @@ impl OxiaClient {
                 address: options.service_address.clone(),
                 namespace: options.namespace.clone(),
                 provider_manager: provider_manager.clone(),
+                request_timeout: options.request_timeout,
             })
             .await?,
         );

--- a/oxia-client/src/shard_manager.rs
+++ b/oxia-client/src/shard_manager.rs
@@ -2,14 +2,14 @@ use crate::address::ensure_protocol;
 use crate::errors::OxiaError;
 use crate::hash::shard_key_hash;
 use crate::oxia::shard_assignment::ShardBoundaries;
-use crate::oxia::{ShardAssignment, ShardAssignmentsRequest, ShardKeyRouter};
+use crate::oxia::{NamespaceShardsAssignment, ShardAssignmentsRequest, ShardKeyRouter};
 use crate::provider_manager::ProviderManager;
 use crate::retry::{retry_until_cancelled, RetryError};
-use dashmap::DashMap;
+use arc_swap::ArcSwap;
 use log::info;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{mpsc, Mutex};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -19,17 +19,80 @@ pub struct ShardManagerOptions {
     pub address: String,
     pub namespace: String,
     pub provider_manager: Arc<ProviderManager>,
+    pub request_timeout: Duration,
 }
+
 pub(crate) struct Node {
     pub service_address: String,
 }
 
+/// One shard's hash range and leader, used to route keys to shards.
+struct ShardRange {
+    min_hash: u32,
+    max_hash: u32,
+    shard: i64,
+    leader: String,
+}
+
+/// An immutable snapshot of a namespace's shard assignments.
+///
+/// The [`ShardManager`] publishes a fresh snapshot atomically via [`ArcSwap`] on
+/// every update, so lookups never observe a half-applied table (the previous
+/// `DashMap` was cleared then repopulated, exposing a window where a key routed
+/// to nothing). Hash ranges are kept sorted so routing is a binary search rather
+/// than a linear scan.
+struct Assignments {
+    shard_key_router: i32,
+    /// Shard hash ranges, sorted ascending by `min_hash`.
+    ranges: Vec<ShardRange>,
+    /// Shard id -> leader address.
+    leaders: HashMap<i64, String>,
+}
+
+impl Assignments {
+    fn empty() -> Self {
+        Assignments {
+            shard_key_router: ShardKeyRouter::Xxhash3 as i32,
+            ranges: Vec::new(),
+            leaders: HashMap::new(),
+        }
+    }
+
+    fn from_namespace(namespace_assignment: &NamespaceShardsAssignment) -> Self {
+        let mut ranges = Vec::with_capacity(namespace_assignment.assignments.len());
+        let mut leaders = HashMap::with_capacity(namespace_assignment.assignments.len());
+        for sa in &namespace_assignment.assignments {
+            leaders.insert(sa.shard, sa.leader.clone());
+            if let Some(ShardBoundaries::Int32HashRange(range)) = &sa.shard_boundaries {
+                ranges.push(ShardRange {
+                    min_hash: range.min_hash_inclusive,
+                    max_hash: range.max_hash_inclusive,
+                    shard: sa.shard,
+                    leader: sa.leader.clone(),
+                });
+            }
+        }
+        ranges.sort_by_key(|r| r.min_hash);
+        Assignments {
+            shard_key_router: namespace_assignment.shard_key_router,
+            ranges,
+            leaders,
+        }
+    }
+
+    /// Finds the shard whose hash range contains `code`, in O(log n).
+    fn shard_for_hash(&self, code: u32) -> Option<&ShardRange> {
+        // The last range whose `min_hash <= code` is the only candidate; check it
+        // actually contains `code` (guards gaps in an incomplete assignment).
+        let idx = self.ranges.partition_point(|r| r.min_hash <= code);
+        let range = self.ranges.get(idx.checked_sub(1)?)?;
+        (code <= range.max_hash).then_some(range)
+    }
+}
+
 struct Inner {
     provider_manager: Arc<ProviderManager>,
-    current_assignments: Arc<DashMap<i64, ShardAssignment>>,
-    /// The [`ShardKeyRouter`] most recently advertised by the namespace, stored
-    /// as its raw enum value. Determines which hash routes keys to shards.
-    shard_key_router: AtomicI32,
+    assignments: ArcSwap<Assignments>,
 }
 
 pub struct ShardManager {
@@ -49,10 +112,9 @@ async fn start_assignments_listener(
     address: String,
     namespace: String,
     inner: Arc<Inner>,
-    init_tx: mpsc::Sender<()>,
+    init_tx: mpsc::Sender<Result<(), OxiaError>>,
 ) {
-    let op_defer = || {
-        let assignments_ref = inner.current_assignments.clone();
+    let op = || {
         let local_address = address.clone();
         let local_inner = inner.clone();
         let local_context = context.clone();
@@ -64,52 +126,70 @@ async fn start_assignments_listener(
                 .get_provider(local_address)
                 .await
                 .map_err(RetryError::transient)?;
-            let mut streaming = provider
+            let mut streaming = match provider
                 .get_shard_assignments(ShardAssignmentsRequest {
                     namespace: ns.clone(),
                 })
                 .await
-                .map_err(|err| RetryError::transient(OxiaError::from(err)))?
-                .into_inner();
+            {
+                Ok(response) => response.into_inner(),
+                Err(status) => return classify_status(status, &init_sender).await,
+            };
             loop {
                 tokio::select! {
                     _ = local_context.cancelled() => {
-                        info!("Close shards assignment stream due to context canceled.");
+                        info!("Shard assignment listener stopped: cancelled.");
                         return Ok(());
                     }
-                    result = streaming.next() => {
-                        if result.is_none() {
-                            info!("Close shards assignment stream due to stream closed.");
-                            return Ok(());
+                    message = streaming.next() => match message {
+                        // A graceful close (e.g. the coordinator restarting) is
+                        // transient: reconnect rather than stop with stale routing.
+                        None => {
+                            return Err(RetryError::transient(OxiaError::Disconnected(
+                                "shard assignment stream closed by server".to_string(),
+                            )));
                         }
-                        match result.unwrap() {
-                        Ok(assignments) => {
-                            let ns_assignments = assignments.namespaces.get(&ns);
-                            if ns_assignments.is_none() {
-                                    continue;
-                            }
-                            let namespace_assignment = ns_assignments.unwrap();
-                            assignments_ref.clear();
-                            for sa in &namespace_assignment.assignments {
-                                assignments_ref.insert(sa.shard, sa.clone());
-                            }
-                            local_inner
-                                .shard_key_router
-                                .store(namespace_assignment.shard_key_router, Ordering::Release);
-                            if !init_sender.is_closed() {
-                                let _ = init_sender.send(()).await;
+                        Some(Err(status)) => return classify_status(status, &init_sender).await,
+                        Some(Ok(assignments)) => {
+                            if let Some(na) = assignments.namespaces.get(&ns) {
+                                local_inner
+                                    .assignments
+                                    .store(Arc::new(Assignments::from_namespace(na)));
+                                if !init_sender.is_closed() {
+                                    let _ = init_sender.send(Ok(())).await;
+                                }
                             }
                         }
-                        Err(stream_status) => {
-                             return Err(RetryError::transient(OxiaError::from(stream_status)));
-                        }
-                    }
                     }
                 }
             }
         }
     };
-    retry_until_cancelled(&context, "shard-assignments", op_defer).await;
+    retry_until_cancelled(&context, "shard-assignments", op).await;
+}
+
+/// Classifies a gRPC error from the assignment stream. `Unauthenticated` (bad
+/// credentials) and `NotFound` (on this stream, only the namespace can be not
+/// found) are permanent — retrying cannot help — so the error is also forwarded
+/// to [`ShardManager::new`] to unblock it immediately. Everything else is
+/// transient and retried.
+async fn classify_status(
+    status: tonic::Status,
+    init_sender: &mpsc::Sender<Result<(), OxiaError>>,
+) -> Result<(), RetryError> {
+    let fatal = matches!(
+        status.code(),
+        tonic::Code::Unauthenticated | tonic::Code::NotFound
+    );
+    let err = OxiaError::from(status);
+    if fatal {
+        if !init_sender.is_closed() {
+            let _ = init_sender.send(Err(err.clone())).await;
+        }
+        Err(RetryError::fatal(err))
+    } else {
+        Err(RetryError::transient(err))
+    }
 }
 
 impl ShardManager {
@@ -117,25 +197,43 @@ impl ShardManager {
         let context = CancellationToken::new();
         let inner = Arc::new(Inner {
             provider_manager: options.provider_manager,
-            current_assignments: Arc::new(DashMap::new()),
-            shard_key_router: AtomicI32::new(ShardKeyRouter::Xxhash3 as i32),
+            assignments: ArcSwap::from_pointee(Assignments::empty()),
         });
-        let (init_tx, mut init_rx) = mpsc::channel(1);
+        let (init_tx, mut init_rx) = mpsc::channel::<Result<(), OxiaError>>(1);
         let assignment_handle = tokio::spawn(start_assignments_listener(
             context.clone(),
             options.address,
-            options.namespace.clone(),
+            options.namespace,
             inner.clone(),
             init_tx,
         ));
 
-        init_rx.recv().await;
-        let sm = ShardManager {
+        // Fail fast: never hand back a client with an empty routing table. Wait
+        // for the first assignment, bounded by the request timeout, and surface a
+        // permanent error (bad namespace or credentials) as soon as it is known.
+        match tokio::time::timeout(options.request_timeout, init_rx.recv()).await {
+            Ok(Some(Ok(()))) => {}
+            Ok(Some(Err(err))) => {
+                context.cancel();
+                return Err(err);
+            }
+            Ok(None) => {
+                context.cancel();
+                return Err(OxiaError::Disconnected(
+                    "shard assignment stream ended before delivering any assignment".to_string(),
+                ));
+            }
+            Err(_) => {
+                context.cancel();
+                return Err(OxiaError::Timeout);
+            }
+        }
+
+        Ok(ShardManager {
             inner,
             context,
             assignment_handle: Mutex::new(Some(assignment_handle)),
-        };
-        Ok(sm)
+        })
     }
 
     pub async fn shutdown(self) -> Result<(), OxiaError> {
@@ -150,56 +248,91 @@ impl ShardManager {
     }
 
     pub fn get_leader(&self, shard_id: i64) -> Option<Node> {
-        let assignment_option = self.inner.current_assignments.get(&shard_id);
-        assignment_option.map(|v| Node {
-            service_address: ensure_protocol(v.leader.clone()),
-        })
+        self.inner
+            .assignments
+            .load()
+            .leaders
+            .get(&shard_id)
+            .map(|leader| Node {
+                service_address: ensure_protocol(leader.clone()),
+            })
     }
 
     pub fn get_shard(&self, key: &str) -> Option<i64> {
-        let code = shard_key_hash(self.inner.shard_key_router.load(Ordering::Acquire), key);
-        for entry in self.inner.current_assignments.iter() {
-            if let Some(boundaries) = entry.shard_boundaries.as_ref() {
-                match boundaries {
-                    ShardBoundaries::Int32HashRange(range) => {
-                        if range.min_hash_inclusive <= code && code <= range.max_hash_inclusive {
-                            return Some(entry.shard);
-                        }
-                    }
-                }
-            }
-        }
-        None
+        let snapshot = self.inner.assignments.load();
+        let code = shard_key_hash(snapshot.shard_key_router, key);
+        snapshot.shard_for_hash(code).map(|r| r.shard)
     }
 
     pub fn get_shards_leader(&self) -> HashMap<i64, Node> {
-        let mut map = HashMap::with_capacity(self.inner.current_assignments.len());
-        for item in self.inner.current_assignments.iter() {
-            map.insert(
-                item.shard,
-                Node {
-                    service_address: ensure_protocol(item.leader.clone()),
-                },
-            );
-        }
-        map
+        let snapshot = self.inner.assignments.load();
+        snapshot
+            .leaders
+            .iter()
+            .map(|(shard, leader)| {
+                (
+                    *shard,
+                    Node {
+                        service_address: ensure_protocol(leader.clone()),
+                    },
+                )
+            })
+            .collect()
     }
 
     pub fn get_shard_leader(&self, key: &str) -> Option<Node> {
-        let code = shard_key_hash(self.inner.shard_key_router.load(Ordering::Acquire), key);
-        for entry in self.inner.current_assignments.iter() {
-            if let Some(boundaries) = entry.shard_boundaries.as_ref() {
-                match boundaries {
-                    ShardBoundaries::Int32HashRange(range) => {
-                        if range.min_hash_inclusive <= code && code <= range.max_hash_inclusive {
-                            return Some(Node {
-                                service_address: ensure_protocol(entry.leader.clone()),
-                            });
-                        }
-                    }
-                }
-            }
+        let snapshot = self.inner.assignments.load();
+        let code = shard_key_hash(snapshot.shard_key_router, key);
+        snapshot.shard_for_hash(code).map(|r| Node {
+            service_address: ensure_protocol(r.leader.clone()),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn range(min: u32, max: u32, shard: i64) -> ShardRange {
+        ShardRange {
+            min_hash: min,
+            max_hash: max,
+            shard,
+            leader: format!("leader-{shard}"),
         }
-        None
+    }
+
+    #[test]
+    fn shard_for_hash_binary_search() {
+        let a = Assignments {
+            shard_key_router: ShardKeyRouter::Xxhash3 as i32,
+            ranges: vec![range(0, 99, 1), range(100, 199, 2), range(200, u32::MAX, 3)],
+            leaders: HashMap::new(),
+        };
+        assert_eq!(a.shard_for_hash(0).map(|r| r.shard), Some(1));
+        assert_eq!(a.shard_for_hash(99).map(|r| r.shard), Some(1));
+        assert_eq!(a.shard_for_hash(100).map(|r| r.shard), Some(2));
+        assert_eq!(a.shard_for_hash(150).map(|r| r.shard), Some(2));
+        assert_eq!(a.shard_for_hash(200).map(|r| r.shard), Some(3));
+        assert_eq!(a.shard_for_hash(u32::MAX).map(|r| r.shard), Some(3));
+    }
+
+    #[test]
+    fn shard_for_hash_reports_gaps() {
+        // A gap between 100..=199 that no shard owns.
+        let a = Assignments {
+            shard_key_router: ShardKeyRouter::Xxhash3 as i32,
+            ranges: vec![range(0, 99, 1), range(200, 299, 2)],
+            leaders: HashMap::new(),
+        };
+        assert_eq!(a.shard_for_hash(50).map(|r| r.shard), Some(1));
+        assert_eq!(a.shard_for_hash(150).map(|r| r.shard), None);
+        assert_eq!(a.shard_for_hash(250).map(|r| r.shard), Some(2));
+    }
+
+    #[test]
+    fn empty_assignments_route_nowhere() {
+        let a = Assignments::empty();
+        assert_eq!(a.shard_for_hash(0).map(|r| r.shard), None);
     }
 }

--- a/oxia-client/tests/integration_tests.rs
+++ b/oxia-client/tests/integration_tests.rs
@@ -1716,3 +1716,21 @@ async fn test_concurrent_cas_conflict() {
         .unwrap();
     client.shutdown().await.unwrap();
 }
+
+/// P1-3: building a client against an unreachable cluster must fail fast within
+/// the request timeout instead of returning a client with an empty routing
+/// table (or hanging). No server is started here.
+#[tokio::test]
+async fn build_fails_fast_when_cluster_unreachable() {
+    let build = OxiaClientBuilder::new()
+        .service_address("http://127.0.0.1:1".to_string())
+        .request_timeout(Duration::from_secs(2))
+        .build();
+    // Bound the whole thing well above the request timeout: if `build` returns
+    // an error we failed fast; if this outer timeout fires, it hung.
+    match tokio::time::timeout(Duration::from_secs(15), build).await {
+        Ok(Ok(_)) => panic!("build unexpectedly succeeded against an unreachable cluster"),
+        Ok(Err(_)) => {}
+        Err(_) => panic!("build hung instead of failing fast within the request timeout"),
+    }
+}


### PR DESCRIPTION
Three tightly-coupled shard-manager fixes, all in `shard_manager.rs`.

## P1-3 — fail-fast `new()`
`ShardManager::new()` used to `init_rx.recv().await` and ignore the result: against an unreachable cluster it returned a client with an **empty routing table**, so every later op failed with a routing error. (After the `backoff` removal the watcher retries forever, so this would now *hang* instead.)

Now it waits for the first assignment **bounded by the request timeout**, and on timeout / permanent error it cancels the watcher and returns an error. The init channel carries a `Result<(), OxiaError>`, so a bad namespace or bad credentials surface as the **real** error rather than a generic timeout.

## P1-4 — the watcher stops dying
- A **graceful stream close** (e.g. coordinator restart) previously returned `Ok` → the retry loop stopped → routing stale **forever**. It's now transient → reconnect.
- gRPC **`Unauthenticated`** and **`NotFound`** are classified **permanent** (matching the Go client — on the assignment stream, `NotFound` can only be namespace-not-found, so no error-detail decoding needed) and forwarded to `new()`.

## P1-5 — atomic snapshot + O(log n) routing
Assignments are published as an immutable `Assignments` snapshot via **`ArcSwap`** instead of `clear()`-then-insert on a `DashMap` — which exposed a window where a key routed to **nothing** on every refresh. Routing is now a **binary search** over hash ranges sorted by `min_hash` instead of a linear scan, and the shard-key router rides *in* the snapshot (dropping the separate `AtomicI32`, so router + assignments swap atomically).

## API / deps
- `ShardManagerOptions` gains `request_timeout` (wired from `OxiaClientOptions`).
- Adds `arc-swap` (widely-used, maintained, lock-free).

## Verification
`fmt` + `clippy --all-targets -D warnings` clean. **23** unit tests — incl. new binary-search routing tests (exact boundaries, gaps, empty) — **46** integration (incl. a new `build_fails_fast_when_cluster_unreachable` that returns in **~2 s**, not 15 min), and **2** interop, all green against `oxia/oxia:main`. The 10-shard interop tests exercise the new binary-search routing directly.

## Note
`NotFound`/`Unauthenticated` surface today as `OxiaError::Grpc { code, .. }` (the message carries the server's text, e.g. "oxia: namespace not found"). Dedicated `NamespaceNotFound`/`Unauthenticated` variants could be added later if callers want to match them without inspecting the code.