### PR TITLE
feat: transparent session recreation + configurable keep-alive (P1-6/7)

### DIFF
--- a/oxia-client/src/client.rs
+++ b/oxia-client/src/client.rs
@@ -367,6 +367,7 @@ impl OxiaClient {
         let session_manager = Arc::new(SessionManager::new(
             options.identity.clone(),
             options.session_timeout,
+            options.session_keep_alive,
             shard_manager.clone(),
             provider_manager.clone(),
         ));

--- a/oxia-client/src/client_builder.rs
+++ b/oxia-client/src/client_builder.rs
@@ -30,6 +30,7 @@ pub struct OxiaClientBuilder {
     batch_max_size: Option<u32>,
     max_requests_per_batch: Option<u32>,
     session_timeout: Option<Duration>,
+    session_keep_alive: Option<Duration>,
     request_timeout: Option<Duration>,
 }
 
@@ -73,12 +74,19 @@ impl OxiaClientBuilder {
         self
     }
 
+    /// Interval between session keep-alive heartbeats. Defaults to
+    /// `session_timeout / 10` when not set.
+    pub fn session_keep_alive(mut self, session_keep_alive: Duration) -> Self {
+        self.session_keep_alive = Some(session_keep_alive);
+        self
+    }
+
     pub fn request_timeout(mut self, request_timeout: Duration) -> Self {
         self.request_timeout = Some(request_timeout);
         self
     }
 
-    pub async fn build(self) -> Result<OxiaClient, OxiaError> {
+    fn assemble_options(self) -> OxiaClientOptions {
         let mut options = OxiaClientOptions::default();
         if let Some(service_address) = self.service_address {
             options.service_address = service_address
@@ -101,9 +109,46 @@ impl OxiaClientBuilder {
         if let Some(session_timeout) = self.session_timeout {
             options.session_timeout = session_timeout;
         }
+        // Default the keep-alive interval to session_timeout/10, matching the
+        // reference client, once the final session timeout is known.
+        options.session_keep_alive = self
+            .session_keep_alive
+            .unwrap_or(options.session_timeout / 10);
         if let Some(request_timeout) = self.request_timeout {
             options.request_timeout = request_timeout;
         }
-        OxiaClient::new(options).await
+        options
+    }
+
+    pub async fn build(self) -> Result<OxiaClient, OxiaError> {
+        OxiaClient::new(self.assemble_options()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keep_alive_defaults_to_a_tenth_of_the_session_timeout() {
+        let options = OxiaClientBuilder::new()
+            .session_timeout(Duration::from_secs(30))
+            .assemble_options();
+        assert_eq!(options.session_keep_alive, Duration::from_secs(3));
+    }
+
+    #[test]
+    fn keep_alive_can_be_overridden() {
+        let options = OxiaClientBuilder::new()
+            .session_timeout(Duration::from_secs(30))
+            .session_keep_alive(Duration::from_millis(500))
+            .assemble_options();
+        assert_eq!(options.session_keep_alive, Duration::from_millis(500));
+    }
+
+    #[test]
+    fn default_keep_alive_tracks_the_default_session_timeout() {
+        let options = OxiaClientBuilder::new().assemble_options();
+        assert_eq!(options.session_keep_alive, options.session_timeout / 10);
     }
 }

--- a/oxia-client/src/client_options.rs
+++ b/oxia-client/src/client_options.rs
@@ -18,6 +18,8 @@ pub struct OxiaClientOptions {
     pub max_requests_per_batch: u32,
     /// Session timeout for ephemeral records (default: 15s).
     pub session_timeout: Duration,
+    /// Interval between session keep-alive heartbeats (default: `session_timeout / 10`).
+    pub session_keep_alive: Duration,
     /// Timeout for individual requests (default: 30s).
     pub request_timeout: Duration,
 }
@@ -32,6 +34,7 @@ impl Default for OxiaClientOptions {
             batch_max_size: 128 * 1024,
             max_requests_per_batch: 1000,
             session_timeout: Duration::from_secs(15),
+            session_keep_alive: Duration::from_secs(15) / 10,
             request_timeout: Duration::from_secs(30),
         }
     }

--- a/oxia-client/src/session_manager.rs
+++ b/oxia-client/src/session_manager.rs
@@ -6,6 +6,7 @@ use crate::shard_manager::ShardManager;
 use crate::status::CODE_SESSION_NOT_FOUND;
 use dashmap::DashMap;
 use log::{info, warn};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, OnceCell};
@@ -24,6 +25,9 @@ struct Inner {
 struct Session {
     context: CancellationToken,
     handle: Mutex<Option<JoinHandle<()>>>,
+    /// Set to `false` by the keep-alive task once the server reports the session
+    /// no longer exists, so [`SessionManager::get_session_id`] re-creates it.
+    alive: Arc<AtomicBool>,
     inner: Arc<Inner>,
 }
 
@@ -31,22 +35,25 @@ impl Session {
     pub fn new(
         shard_id: i64,
         session_id: i64,
-        session_timeout: Duration,
+        keep_alive_interval: Duration,
         shard_manager: Arc<ShardManager>,
         provider_manager: Arc<ProviderManager>,
     ) -> Self {
         let context = CancellationToken::new();
+        let alive = Arc::new(AtomicBool::new(true));
         let handle = Mutex::new(Some(tokio::spawn(start_keep_alive(
             context.clone(),
             shard_manager.clone(),
             provider_manager.clone(),
             shard_id,
             session_id,
-            session_timeout,
+            keep_alive_interval,
+            alive.clone(),
         ))));
         let session = Self {
             handle,
             context,
+            alive,
             inner: Arc::new(Inner {
                 id: session_id,
                 shard_id,
@@ -60,6 +67,12 @@ impl Session {
         );
         session
     }
+
+    /// Whether the session is still believed valid. Turns `false` once the
+    /// keep-alive observes that the server has expired it.
+    fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::Acquire)
+    }
 }
 
 impl Drop for Session {
@@ -68,20 +81,21 @@ impl Drop for Session {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn start_keep_alive(
     context: CancellationToken,
     shard_manager: Arc<ShardManager>,
     provider_manager: Arc<ProviderManager>,
     shard_id: i64,
     session_id: i64,
-    session_timeout: Duration,
+    keep_alive_interval: Duration,
+    alive: Arc<AtomicBool>,
 ) {
-    // Send heartbeats at 1/3 of the session timeout to ensure we don't miss
-    let heartbeat_interval = session_timeout / 3;
     let op_defer = || {
         let local_shard_manager = shard_manager.clone();
         let local_provider_manager = provider_manager.clone();
         let local_context = context.clone();
+        let local_alive = alive.clone();
         async move {
             match local_shard_manager.get_leader(shard_id) {
                 None => Err(RetryError::transient(OxiaError::LeaderNotFound {
@@ -92,7 +106,7 @@ async fn start_keep_alive(
                         .get_provider(leader.service_address)
                         .await
                         .map_err(RetryError::transient)?;
-                    let mut ticker = interval(heartbeat_interval);
+                    let mut ticker = interval(keep_alive_interval);
                     loop {
                         tokio::select! {
                             _ = local_context.cancelled() => {
@@ -100,16 +114,18 @@ async fn start_keep_alive(
                                 return Ok(());
                             },
                             _ = ticker.tick() => {
-                                provider
+                                if let Err(err) = provider
                                     .keep_alive(Request::new(SessionHeartbeat { shard: shard_id, session_id }))
                                     .await
-                                    .map_err(|err| {
-                                        if err.code() as i32 == CODE_SESSION_NOT_FOUND {
-                                            info!("Session keep-alive exit due to session not found.");
-                                            return RetryError::fatal(OxiaError::SessionExpired);
-                                        }
-                                        RetryError::transient(OxiaError::from(err))
-                                    })?;
+                                {
+                                    if err.code() as i32 == CODE_SESSION_NOT_FOUND {
+                                        info!("Session {session_id} on shard {shard_id} expired; it will be re-created on next use.");
+                                        // Mark dead so get_session_id re-creates it, then stop.
+                                        local_alive.store(false, Ordering::Release);
+                                        return Err(RetryError::fatal(OxiaError::SessionExpired));
+                                    }
+                                    return Err(RetryError::transient(OxiaError::from(err)));
+                                }
                             }
                         }
                     }
@@ -157,6 +173,7 @@ impl Session {
 pub(crate) struct SessionManager {
     identity: String,
     session_timeout: Duration,
+    session_keep_alive: Duration,
     sessions: DashMap<i64, OnceCell<Session>>,
     shard_manager: Arc<ShardManager>,
     provider_manager: Arc<ProviderManager>,
@@ -166,12 +183,14 @@ impl SessionManager {
     pub(crate) fn new(
         identity: String,
         session_timeout: Duration,
+        session_keep_alive: Duration,
         shard_manager: Arc<ShardManager>,
         provider_manager: Arc<ProviderManager>,
     ) -> Self {
         SessionManager {
             identity,
             session_timeout,
+            session_keep_alive,
             sessions: DashMap::new(),
             shard_manager,
             provider_manager,
@@ -179,7 +198,13 @@ impl SessionManager {
     }
 
     pub(crate) async fn get_session_id(&self, shard_id: i64) -> Result<i64, OxiaError> {
-        let session_cell = self.sessions.entry(shard_id).or_default();
+        let mut session_cell = self.sessions.entry(shard_id).or_default();
+        // If a previously created session has expired (its keep-alive saw
+        // SESSION_NOT_FOUND), discard it so a fresh one is created below — the
+        // caller then transparently gets a working session.
+        if session_cell.get().is_some_and(|s| !s.is_alive()) {
+            *session_cell = OnceCell::new();
+        }
         let session = session_cell
             .get_or_try_init(|| async {
                 match self.shard_manager.get_leader(shard_id) {
@@ -201,7 +226,7 @@ impl SessionManager {
                         Ok(Session::new(
                             shard_id,
                             session_id,
-                            self.session_timeout,
+                            self.session_keep_alive,
                             self.shard_manager.clone(),
                             self.provider_manager.clone(),
                         ))


### PR DESCRIPTION
## P1-6 — sessions recreate themselves after expiry
Before: when a session's keep-alive got `SESSION_NOT_FOUND` (the server expired it), the keep-alive stopped but the dead `Session` stayed cached in the per-shard map — so **every subsequent ephemeral op reused the invalid session id and failed with `SessionExpired` forever**.

Now: the keep-alive flips an `alive: AtomicBool` to `false` on `SESSION_NOT_FOUND` and stops. `get_session_id()` discards a dead `Session` and creates a fresh one on the next ephemeral op, so the caller transparently gets a working session. This mirrors the Go client, which deletes the expired session from its per-shard map. Eviction happens on the reader side (which already holds the entry lock), so there's no cross-task `DashMap` contention.

## P1-7 — configurable keep-alive interval
- New `OxiaClientBuilder::session_keep_alive(Duration)`.
- Default is now **`session_timeout / 10`** (matching the Go client), replacing the hardcoded `session_timeout / 3`. The default auto-scales with a custom `session_timeout`.
- "Retry until cancelled" was already satisfied by the earlier `backoff` → `retry_until_cancelled` change (unbounded, cancellation-bound); `SESSION_NOT_FOUND` is the one intentional permanent stop (→ evict + recreate).

## Also
`OxiaClientBuilder::build()` now delegates to a private `assemble_options()`, so the option logic is unit-testable without a live server.

## Verification
`fmt` + `clippy --all-targets -D warnings` clean. **26** unit (3 new: keep-alive default `= session_timeout/10`, override, default-tracking), **46** integration (incl. `test_ephemeral_keys`), **2** interop — all green against `oxia/oxia:main`.

## Deferred
A **deterministic** session-expiry→recreate *integration* test needs failure injection (network partition via toxiproxy, or the mock server from P4-1) — you can't expire a session while its keep-alive is healthy. Tracked for the **P1-G** failure-mode suite. The logic here is covered by review + the `alive`-flag mechanics.