### PR TITLE
feat: RPC deadlines, connect timeout, HTTP/2 keep-alive (P1-8)

### DIFF
--- a/oxia-client/src/batch.rs
+++ b/oxia-client/src/batch.rs
@@ -9,8 +9,9 @@ use crate::provider_manager::ProviderManager;
 use crate::shard_manager::ShardManager;
 use crate::write_stream_manager::WriteStreamManager;
 use std::sync::Arc;
+use std::time::Duration;
 use tonic::codegen::tokio_stream::StreamExt;
-use tonic::{Response, Streaming};
+use tonic::{Request, Response, Streaming};
 
 pub enum Batch {
     Read(ReadBatch),
@@ -52,6 +53,7 @@ pub(crate) struct ReadBatch {
     shard_manager: Arc<ShardManager>,
     provider_manager: Arc<ProviderManager>,
     max_requests: u32,
+    request_timeout: Duration,
 }
 impl ReadBatch {
     pub fn new(
@@ -59,6 +61,7 @@ impl ReadBatch {
         shard_manager: Arc<ShardManager>,
         provider_manager: Arc<ProviderManager>,
         max_requests: u32,
+        request_timeout: Duration,
     ) -> Self {
         ReadBatch {
             get_inflight: Vec::new(),
@@ -66,6 +69,7 @@ impl ReadBatch {
             shard_manager,
             provider_manager,
             max_requests,
+            request_timeout,
         }
     }
 
@@ -105,6 +109,8 @@ impl ReadBatch {
                 for operation in self.get_inflight.iter() {
                     request.gets.push(operation.to_proto());
                 }
+                let mut request = Request::new(request);
+                request.set_timeout(self.request_timeout);
                 match provider.read(request).await {
                     Ok(response) => {
                         if let Err(err) = self.receive_all(response).await {

--- a/oxia-client/src/batch_manager.rs
+++ b/oxia-client/src/batch_manager.rs
@@ -27,6 +27,7 @@ impl Batcher {
         provider_manager: Arc<ProviderManager>,
         write_stream_manager: Arc<WriteStreamManager>,
         max_requests_per_batch: u32,
+        request_timeout: Duration,
     ) -> Batch {
         match self {
             Batcher::Read => Batch::Read(ReadBatch::new(
@@ -34,6 +35,7 @@ impl Batcher {
                 shard_manager,
                 provider_manager,
                 max_requests_per_batch,
+                request_timeout,
             )),
             Batcher::Write => Batch::Write(WriteBatch::new(
                 shard_id,
@@ -67,6 +69,7 @@ impl BatchManager {
         batch_linger: Duration,
         _batch_max_size: u32,
         max_requests_per_batch: u32,
+        request_timeout: Duration,
     ) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
         let context = CancellationToken::new();
@@ -80,6 +83,7 @@ impl BatchManager {
             write_stream_manager,
             batch_linger,
             max_requests_per_batch,
+            request_timeout,
         ));
         BatchManager {
             context,
@@ -119,6 +123,7 @@ async fn start_batcher(
     write_stream_manager: Arc<WriteStreamManager>,
     batch_linger: Duration,
     max_requests_per_batch: u32,
+    request_timeout: Duration,
 ) {
     let mut buffer = Vec::new();
     let mut batch = batcher.create_batch(
@@ -127,6 +132,7 @@ async fn start_batcher(
         provider_manager.clone(),
         write_stream_manager.clone(),
         max_requests_per_batch,
+        request_timeout,
     );
     let mut interval = interval(batch_linger);
     loop {
@@ -140,7 +146,7 @@ async fn start_batcher(
                    continue
                 }
                 batch.flush().await;
-                batch = batcher.create_batch( shard_id, shard_manager.clone(), provider_manager.clone(), write_stream_manager.clone(), max_requests_per_batch);
+                batch = batcher.create_batch( shard_id, shard_manager.clone(), provider_manager.clone(), write_stream_manager.clone(), max_requests_per_batch, request_timeout);
             }
             size = rx.recv_many(&mut buffer, usize::MAX) => {
                 if size == 0 {
@@ -150,7 +156,7 @@ async fn start_batcher(
                 for operation  in buffer.drain(..) {
                     if !batch.can_add(&operation) {
                         batch.flush().await;
-                        batch = batcher.create_batch( shard_id, shard_manager.clone(), provider_manager.clone(), write_stream_manager.clone(), max_requests_per_batch);
+                        batch = batcher.create_batch( shard_id, shard_manager.clone(), provider_manager.clone(), write_stream_manager.clone(), max_requests_per_batch, request_timeout);
                         interval.reset();
                     }
                     batch.add(operation);

--- a/oxia-client/src/client.rs
+++ b/oxia-client/src/client.rs
@@ -349,7 +349,7 @@ pub struct OxiaClient {
 
 impl OxiaClient {
     pub async fn new(options: OxiaClientOptions) -> Result<OxiaClient, OxiaError> {
-        let provider_manager = Arc::new(ProviderManager::new());
+        let provider_manager = Arc::new(ProviderManager::new(options.request_timeout));
         let shard_manager = Arc::new(
             ShardManager::new(ShardManagerOptions {
                 address: options.service_address.clone(),
@@ -363,11 +363,13 @@ impl OxiaClient {
             options.namespace.clone(),
             shard_manager.clone(),
             provider_manager.clone(),
+            options.request_timeout,
         ));
         let session_manager = Arc::new(SessionManager::new(
             options.identity.clone(),
             options.session_timeout,
             options.session_keep_alive,
+            options.request_timeout,
             shard_manager.clone(),
             provider_manager.clone(),
         ));
@@ -545,6 +547,7 @@ impl OxiaClient {
                 self.inner.options.batch_linger,
                 self.inner.options.batch_max_size,
                 self.inner.options.max_requests_per_batch,
+                self.inner.options.request_timeout,
             ))
         };
         let ref_mut = match batcher {
@@ -720,6 +723,7 @@ impl Client for OxiaClient {
                         leader,
                         local_operation,
                         self.inner.provider_manager.clone(),
+                        self.request_timeout(),
                     )
                     .await
                 }
@@ -732,6 +736,7 @@ impl Client for OxiaClient {
                 leader,
                 local_operation,
                 self.inner.provider_manager.clone(),
+                self.request_timeout(),
             ));
         }
         let mut output_keys: Vec<String> = Vec::new();
@@ -776,6 +781,7 @@ impl Client for OxiaClient {
                         leader,
                         local_operation,
                         self.inner.provider_manager.clone(),
+                        self.request_timeout(),
                     )
                     .await
                 }
@@ -788,6 +794,7 @@ impl Client for OxiaClient {
                 leader,
                 local_operation,
                 self.inner.provider_manager.clone(),
+                self.request_timeout(),
             ));
         }
         let mut output_records: Vec<GetResult> = Vec::new();
@@ -1031,14 +1038,14 @@ async fn range_scan_from_single_shard(
     leader: Node,
     local_operation: RangeScanOperation,
     provider_manager: Arc<ProviderManager>,
+    request_timeout: Duration,
 ) -> Result<RangeScanResult, OxiaError> {
     let mut provider = provider_manager
         .get_provider(leader.service_address)
         .await?;
-    let mut streaming = provider
-        .range_scan(Request::new(local_operation.to_proto()))
-        .await?
-        .into_inner();
+    let mut request = Request::new(local_operation.to_proto());
+    request.set_timeout(request_timeout);
+    let mut streaming = provider.range_scan(request).await?.into_inner();
     let mut records = Vec::new();
     while let Some(response) = streaming.next().await {
         match response {
@@ -1064,14 +1071,14 @@ async fn list_from_single_shard(
     leader: Node,
     local_operation: ListOperation,
     provider_manager: Arc<ProviderManager>,
+    request_timeout: Duration,
 ) -> Result<ListResult, OxiaError> {
     let mut provider = provider_manager
         .get_provider(leader.service_address)
         .await?;
-    let mut streaming = provider
-        .list(Request::new(local_operation.to_proto()))
-        .await?
-        .into_inner();
+    let mut request = Request::new(local_operation.to_proto());
+    request.set_timeout(request_timeout);
+    let mut streaming = provider.list(request).await?.into_inner();
     let mut keys = Vec::new();
     while let Some(response) = streaming.next().await {
         match response {

--- a/oxia-client/src/provider_manager.rs
+++ b/oxia-client/src/provider_manager.rs
@@ -2,11 +2,22 @@ use crate::errors::OxiaError;
 use crate::oxia::oxia_client_client::OxiaClientClient;
 use dashmap::DashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::OnceCell;
-use tonic::transport::Channel;
+use tonic::transport::{Channel, Endpoint};
+
+/// HTTP/2 keep-alive settings, matching the reference client. The server enforces
+/// a minimum client ping interval of 5s and permits pings without an active
+/// stream, so a 10s interval is safe. Keep-alive lets a silently-dead connection
+/// (e.g. a dropped NAT mapping) be detected instead of leaving the long-lived
+/// streams — assignments, notifications, sequence updates, the write stream —
+/// hanging forever.
+const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(10);
+const KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(3);
 
 pub struct ProviderManager {
     providers: Arc<DashMap<String, OnceCell<OxiaClientClient<Channel>>>>,
+    connect_timeout: Duration,
 }
 
 impl ProviderManager {
@@ -15,19 +26,27 @@ impl ProviderManager {
         address: String,
     ) -> Result<OxiaClientClient<Channel>, OxiaError> {
         let once_cell = self.providers.entry(address.clone()).or_default();
+        let connect_timeout = self.connect_timeout;
         let client = once_cell
-            .get_or_try_init(|| async {
-                let client = OxiaClientClient::connect(address).await?;
-                Ok::<OxiaClientClient<Channel>, OxiaError>(client.clone())
+            .get_or_try_init(|| async move {
+                let channel = Endpoint::from_shared(address)?
+                    .connect_timeout(connect_timeout)
+                    .keep_alive_while_idle(true)
+                    .http2_keep_alive_interval(KEEP_ALIVE_INTERVAL)
+                    .keep_alive_timeout(KEEP_ALIVE_TIMEOUT)
+                    .connect()
+                    .await?;
+                Ok::<OxiaClientClient<Channel>, OxiaError>(OxiaClientClient::new(channel))
             })
             .await?
             .clone();
         Ok(client)
     }
 
-    pub fn new() -> ProviderManager {
+    pub fn new(connect_timeout: Duration) -> ProviderManager {
         ProviderManager {
             providers: Arc::new(DashMap::new()),
+            connect_timeout,
         }
     }
 

--- a/oxia-client/src/session_manager.rs
+++ b/oxia-client/src/session_manager.rs
@@ -28,6 +28,7 @@ struct Session {
     /// Set to `false` by the keep-alive task once the server reports the session
     /// no longer exists, so [`SessionManager::get_session_id`] re-creates it.
     alive: Arc<AtomicBool>,
+    request_timeout: Duration,
     inner: Arc<Inner>,
 }
 
@@ -36,6 +37,7 @@ impl Session {
         shard_id: i64,
         session_id: i64,
         keep_alive_interval: Duration,
+        request_timeout: Duration,
         shard_manager: Arc<ShardManager>,
         provider_manager: Arc<ProviderManager>,
     ) -> Self {
@@ -48,12 +50,14 @@ impl Session {
             shard_id,
             session_id,
             keep_alive_interval,
+            request_timeout,
             alive.clone(),
         ))));
         let session = Self {
             handle,
             context,
             alive,
+            request_timeout,
             inner: Arc::new(Inner {
                 id: session_id,
                 shard_id,
@@ -89,6 +93,7 @@ async fn start_keep_alive(
     shard_id: i64,
     session_id: i64,
     keep_alive_interval: Duration,
+    request_timeout: Duration,
     alive: Arc<AtomicBool>,
 ) {
     let op_defer = || {
@@ -114,9 +119,9 @@ async fn start_keep_alive(
                                 return Ok(());
                             },
                             _ = ticker.tick() => {
-                                if let Err(err) = provider
-                                    .keep_alive(Request::new(SessionHeartbeat { shard: shard_id, session_id }))
-                                    .await
+                                let mut heartbeat = Request::new(SessionHeartbeat { shard: shard_id, session_id });
+                                heartbeat.set_timeout(request_timeout);
+                                if let Err(err) = provider.keep_alive(heartbeat).await
                                 {
                                     if err.code() as i32 == CODE_SESSION_NOT_FOUND {
                                         info!("Session {session_id} on shard {shard_id} expired; it will be re-created on next use.");
@@ -142,13 +147,12 @@ impl Session {
         let provider_manager = self.inner.provider_manager.clone();
         if let Some(node) = shard_manager.get_leader(self.inner.shard_id) {
             let mut provider = provider_manager.get_provider(node.service_address).await?;
-            let result = provider
-                .close_session(Request::new(CloseSessionRequest {
-                    shard: self.inner.shard_id,
-                    session_id: self.inner.id,
-                }))
-                .await
-                .map_err(OxiaError::from);
+            let mut close = Request::new(CloseSessionRequest {
+                shard: self.inner.shard_id,
+                session_id: self.inner.id,
+            });
+            close.set_timeout(self.request_timeout);
+            let result = provider.close_session(close).await.map_err(OxiaError::from);
             if let Err(err) = result {
                 warn!(
                     "Failed to close session. shard_id={:?} session_id={:?} error={:?}",
@@ -174,6 +178,7 @@ pub(crate) struct SessionManager {
     identity: String,
     session_timeout: Duration,
     session_keep_alive: Duration,
+    request_timeout: Duration,
     sessions: DashMap<i64, OnceCell<Session>>,
     shard_manager: Arc<ShardManager>,
     provider_manager: Arc<ProviderManager>,
@@ -184,6 +189,7 @@ impl SessionManager {
         identity: String,
         session_timeout: Duration,
         session_keep_alive: Duration,
+        request_timeout: Duration,
         shard_manager: Arc<ShardManager>,
         provider_manager: Arc<ProviderManager>,
     ) -> Self {
@@ -191,6 +197,7 @@ impl SessionManager {
             identity,
             session_timeout,
             session_keep_alive,
+            request_timeout,
             sessions: DashMap::new(),
             shard_manager,
             provider_manager,
@@ -214,12 +221,14 @@ impl SessionManager {
                             .provider_manager
                             .get_provider(node.service_address)
                             .await?;
+                        let mut create = Request::new(CreateSessionRequest {
+                            shard: shard_id,
+                            session_timeout_ms: self.session_timeout.as_millis() as u32,
+                            client_identity: self.identity.clone(),
+                        });
+                        create.set_timeout(self.request_timeout);
                         let response = provider
-                            .create_session(Request::new(CreateSessionRequest {
-                                shard: shard_id,
-                                session_timeout_ms: self.session_timeout.as_millis() as u32,
-                                client_identity: self.identity.clone(),
-                            }))
+                            .create_session(create)
                             .await
                             .map_err(OxiaError::from)?;
                         let session_id = response.into_inner().session_id;
@@ -227,6 +236,7 @@ impl SessionManager {
                             shard_id,
                             session_id,
                             self.session_keep_alive,
+                            self.request_timeout,
                             self.shard_manager.clone(),
                             self.provider_manager.clone(),
                         ))

--- a/oxia-client/src/write_stream.rs
+++ b/oxia-client/src/write_stream.rs
@@ -3,6 +3,7 @@ use crate::oxia::{WriteRequest, WriteResponse};
 use log::{info, warn};
 use std::collections::VecDeque;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot::Receiver;
 use tokio::sync::{oneshot, Mutex};
@@ -32,6 +33,7 @@ pub(crate) struct WriteStream {
     inner: Arc<Mutex<Inner>>,
     defer_response: Mutex<Option<Receiver<WriteResponse>>>,
     handle: Mutex<Option<JoinHandle<()>>>,
+    request_timeout: Duration,
 }
 
 impl Drop for WriteStream {
@@ -82,23 +84,37 @@ impl WriteStream {
             return Err(OxiaError::Disconnected(err.to_string()));
         }
         drop(inner_guard);
-        rx.await
-            .map_err(|err| OxiaError::Disconnected(err.to_string()))
+        self.await_response(rx).await
     }
 
     pub(crate) async fn get_defer_response(&self) -> Option<Result<WriteResponse, OxiaError>> {
         let mut guard = self.defer_response.lock().await;
-        let option = guard.take();
-        option.as_ref()?;
-        Some(
-            option
-                .unwrap()
-                .await
-                .map_err(|err| OxiaError::Disconnected(err.to_string())),
-        )
+        let rx = guard.take()?;
+        drop(guard);
+        Some(self.await_response(rx).await)
     }
 
-    pub(crate) fn new(tx: UnboundedSender<WriteRequest>) -> Self {
+    /// Waits for a batch's response, bounded by the request timeout. A timeout
+    /// means the stream is wedged (the server stopped responding): mark it dead
+    /// and fail its in-flight requests so the caller sees a `Timeout` and the
+    /// next write tears the stream down and re-creates it.
+    async fn await_response(
+        &self,
+        rx: Receiver<WriteResponse>,
+    ) -> Result<WriteResponse, OxiaError> {
+        match tokio::time::timeout(self.request_timeout, rx).await {
+            Ok(Ok(response)) => Ok(response),
+            Ok(Err(err)) => Err(OxiaError::Disconnected(err.to_string())),
+            Err(_) => {
+                let mut inner_guard = self.inner.lock().await;
+                inner_guard.alive = false;
+                inner_guard.fail_inflight();
+                Err(OxiaError::Timeout)
+            }
+        }
+    }
+
+    pub(crate) fn new(tx: UnboundedSender<WriteRequest>, request_timeout: Duration) -> Self {
         let inner = Arc::new(Mutex::new(Inner {
             alive: true,
             tx,
@@ -110,6 +126,7 @@ impl WriteStream {
             inner,
             defer_response: Mutex::new(None),
             handle: Mutex::new(None),
+            request_timeout,
         }
     }
 

--- a/oxia-client/src/write_stream_manager.rs
+++ b/oxia-client/src/write_stream_manager.rs
@@ -5,6 +5,7 @@ use crate::shard_manager::ShardManager;
 use crate::write_stream::WriteStream;
 use dashmap::DashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{mpsc, OnceCell};
 use tokio::task::JoinSet;
 use tonic::codegen::tokio_stream::wrappers::UnboundedReceiverStream;
@@ -17,6 +18,7 @@ pub struct WriteStreamManager {
     namespace: String,
     shard_manager: Arc<ShardManager>,
     provider_manager: Arc<ProviderManager>,
+    request_timeout: Duration,
 
     streams: DashMap<i64, OnceCell<WriteStream>>,
 }
@@ -58,7 +60,7 @@ impl WriteStreamManager {
             // https://github.com/hyperium/hyper/issues/3737
             // We should put the first message into the stream to trigger it to actually send.
             // otherwise, write_stream will hang forever.
-            let w_stream = WriteStream::new(tx);
+            let w_stream = WriteStream::new(tx, self.request_timeout);
             w_stream.send_defer(request.clone()).await?;
             let streaming = provider
                 .write_stream(write_stream_request)
@@ -106,11 +108,13 @@ impl WriteStreamManager {
         namespace: String,
         shard_manager: Arc<ShardManager>,
         provider_manager: Arc<ProviderManager>,
+        request_timeout: Duration,
     ) -> Self {
         WriteStreamManager {
             namespace,
             shard_manager,
             provider_manager,
+            request_timeout,
             streams: DashMap::new(),
         }
     }


### PR DESCRIPTION
Closes the "a hung connection wedges a shard's batcher forever" gap. Previously the caller-side `request_timeout` bounded only the caller's own wait; the underlying RPCs and the write stream had **no** deadline, so a stuck `flush` blocked the batcher task and poisoned the shard.

## Connection — connect timeout + HTTP/2 keep-alive (`provider_manager`)
The tonic channel is now built with:
- `connect_timeout` = `request_timeout`;
- **HTTP/2 keep-alive**: 10s interval / 3s timeout / keep-alive-while-idle — matching the reference client, and safely above the server's enforced 5s `MinTime` (`PermitWithoutStream = true`).

Keep-alive is what detects a **silently-dead** connection (dropped NAT mapping, hard partition) that would otherwise leave the long-lived streams — assignments, notifications, sequence updates, the write stream — hanging forever with no error and no reconnect.

## Write stream — bounded response + teardown (`write_stream`)
Each batch's response wait is bounded by `request_timeout`. On timeout the stream is marked dead and its in-flight requests are failed, so the caller gets `Timeout` and the **next write tears the stream down and re-creates it** — the batcher continues instead of wedging. This is the plan's "a wedged stream fails the batch, tears down, batcher continues."

## Per-request gRPC deadlines
`set_timeout(request_timeout)` on the request/response calls that should complete promptly: the batched **Read**, **List**, **RangeScan**, and the session **create / keep-alive / close** RPCs. The long-lived streams intentionally get **no** per-request deadline (they're indefinite) and rely on keep-alive.

## Wiring
`request_timeout` is threaded from the client options into the provider manager, write-stream manager, read batch (via the batcher), session manager, and the list/range_scan helpers.

## Verification
`fmt` + `clippy --all-targets -D warnings` clean. **26** unit, **46** integration, **2** interop — all green against `oxia/oxia:main`. The integration suite exercises every newly-deadlined path (get→Read, put→write stream, list, range_scan, ephemeral→sessions).

## Deferred
Deterministic **wedge-recovery** tests (hang a connection, assert the batcher recovers) need failure injection — toxiproxy or the P4-1 mock server — and are tracked for the **P1-G** failure suite. This PR verifies the deadlines don't disturb the happy paths and wires them everywhere.