### PR TITLE
feat: op-level retries with retryable classification + leader hints (P1-11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,6 +1115,7 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tonic-build",
+ "tonic-types",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2025,6 +2026,17 @@ dependencies = [
  "prost-types",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07439468da24d5f211d3f3bd7b63665d8f45072804457e838a87414a478e2db8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ resolver = "2"
 
 [workspace.dependencies]
 tonic = "0.13"
+tonic-types = "0.13"
 prost = "0.13"
 tokio = { version = "1.47.0", features = ["rt-multi-thread", "macros"] }
 thiserror = "2.0.12"

--- a/oxia-client/Cargo.toml
+++ b/oxia-client/Cargo.toml
@@ -29,6 +29,7 @@ arc-swap = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
+tonic-types = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/oxia-client/src/batcher.rs
+++ b/oxia-client/src/batcher.rs
@@ -24,14 +24,17 @@
 //! stream order always equals dispatch order. Reads have no ordering
 //! constraint and run as independent RPCs.
 
+use crate::address::ensure_protocol;
 use crate::errors::OxiaError;
 use crate::operations::{Pending, PendingDelete, PendingDeleteRange, PendingGet, PendingPut};
 use crate::proto;
 use crate::provider_manager::ProviderManager;
+use crate::retry::retry_delay;
+use crate::server_error::{DecodedStatus, LeaderHint, decode_status};
 use crate::shard_manager::ShardManager;
 use std::collections::VecDeque;
-use std::sync::{Arc, Mutex, MutexGuard};
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{self, UnboundedReceiver};
 use tokio::sync::{Notify, oneshot};
 use tonic::Streaming;
@@ -240,11 +243,32 @@ impl WriteCallbacks {
     }
 }
 
+/// An in-flight (or retryable) write batch: the wire request is retained so a
+/// retryable stream failure can re-send it — values are `Bytes`, so keeping it
+/// is refcount-cheap.
+struct InFlightWrite {
+    request: proto::WriteRequest,
+    callbacks: WriteCallbacks,
+    /// When the batch was first dispatched; retries stop once the batch is
+    /// older than the request timeout.
+    first_dispatch: Instant,
+}
+
 struct WriteState {
     queues: Queues<WriteBody>,
-    /// Callbacks of in-flight batches, FIFO-matched with stream responses.
+    /// In-flight batches, FIFO-matched with stream responses.
     /// `pending.len()` *is* the number of batches in flight.
-    pending: VecDeque<WriteCallbacks>,
+    pending: VecDeque<InFlightWrite>,
+    /// Batches whose stream failed retryably, awaiting redispatch. Older than
+    /// anything in `queues`, so they go out first.
+    retry: VecDeque<InFlightWrite>,
+    /// Leader hint from the last routing failure; steers the next stream
+    /// connect until a response confirms the leader.
+    hint: Option<LeaderHint>,
+    /// True while a post-failure backoff sleep is pending; blocks dispatch so
+    /// a dead leader is not hammered in a tight reconnect loop.
+    reconnecting: bool,
+    failure_streak: u32,
     /// Sender feeding the shard's write-stream RPC; `None` until the first
     /// dispatch and after a stream failure.
     stream_tx: Option<mpsc::UnboundedSender<proto::WriteRequest>>,
@@ -269,6 +293,10 @@ impl WriteBatcher {
             state: Mutex::new(WriteState {
                 queues: Queues::default(),
                 pending: VecDeque::new(),
+                retry: VecDeque::new(),
+                hint: None,
+                reconnecting: false,
+                failure_streak: 0,
                 stream_tx: None,
                 parked: None,
                 pump_running: false,
@@ -291,11 +319,10 @@ impl WriteBatcher {
             if st.queues.closed {
                 Some(op)
             } else {
-                let capacity = self.deps.max_write_batches_in_flight;
                 let mut open = st.queues.open.take().unwrap_or_default();
                 // Seal the open batch when this operation would overflow it.
                 if !open.is_empty() && open.bytes + size > self.deps.max_batch_size {
-                    if st.pending.len() < capacity {
+                    if self.can_dispatch(&st) {
                         self.dispatch_locked(&mut st, open);
                     } else {
                         st.queues.ready.push_back(open);
@@ -304,7 +331,7 @@ impl WriteBatcher {
                 }
                 open.push(op, size);
                 if open.count >= self.deps.max_requests_per_batch {
-                    if st.pending.len() < capacity {
+                    if self.can_dispatch(&st) {
                         self.dispatch_locked(&mut st, open);
                     } else {
                         st.queues.ready.push_back(open);
@@ -314,8 +341,9 @@ impl WriteBatcher {
                     // Adaptive dispatch: with window capacity available, flush
                     // the open batch after one scheduler yield (coalescing
                     // whatever arrives in the meantime). With the window
-                    // exhausted, do nothing — a completion will pick it up.
-                    if st.pending.len() < capacity && !st.queues.flush_scheduled {
+                    // exhausted (or a reconnect backoff pending), do nothing —
+                    // a completion or the reconnect will pick it up.
+                    if self.can_dispatch(&st) && !st.queues.flush_scheduled {
                         st.queues.flush_scheduled = true;
                         spawn_flusher = true;
                     }
@@ -343,10 +371,24 @@ impl WriteBatcher {
         self.fill_capacity(&mut st);
     }
 
-    /// Dispatches queued batches (sealed first, then open) while the window
-    /// has capacity. Must be called with the state lock held.
+    fn can_dispatch(&self, st: &WriteState) -> bool {
+        !st.reconnecting && st.pending.len() < self.deps.max_write_batches_in_flight
+    }
+
+    /// Dispatches queued batches — retries first (they are the oldest), then
+    /// sealed batches, then the open one — while the window has capacity.
+    /// Retries whose deadline has passed fail here instead of being re-sent.
+    /// Must be called with the state lock held.
     fn fill_capacity(self: &Arc<Self>, st: &mut WriteState) {
-        while st.pending.len() < self.deps.max_write_batches_in_flight {
+        while self.can_dispatch(st) {
+            if let Some(inflight) = st.retry.pop_front() {
+                if inflight.first_dispatch.elapsed() >= self.deps.request_timeout {
+                    inflight.callbacks.fail(&OxiaError::Timeout);
+                    continue;
+                }
+                self.send_locked(st, inflight);
+                continue;
+            }
             match st.queues.take_next() {
                 Some(body) => self.dispatch_locked(st, body),
                 None => break,
@@ -359,9 +401,24 @@ impl WriteBatcher {
     /// server-side apply order both equal dispatch order.
     fn dispatch_locked(self: &Arc<Self>, st: &mut WriteState, body: WriteBody) {
         let (request, callbacks) = body.into_request(self.shard);
-        st.pending.push_back(callbacks);
+        self.send_locked(
+            st,
+            InFlightWrite {
+                request,
+                callbacks,
+                first_dispatch: Instant::now(),
+            },
+        );
+    }
+
+    /// Sends an in-flight batch (fresh or retried) on the stream, creating the
+    /// stream and pump as needed. Must be called with the state lock held.
+    fn send_locked(self: &Arc<Self>, st: &mut WriteState, inflight: InFlightWrite) {
+        let request = inflight.request.clone();
+        st.pending.push_back(inflight);
 
         if st.stream_tx.is_none() {
+            debug!(shard = self.shard, "creating write stream");
             // Fresh stream: requests queue in the channel while the pump
             // connects (tonic requires the first message to be queued before
             // the RPC call for the stream to open).
@@ -377,6 +434,7 @@ impl WriteBatcher {
                 .take()
                 .expect("idle write stream must have a parked response stream");
             st.pump_running = true;
+            debug!(shard = self.shard, "resuming write-stream pump");
             let this = self.clone();
             tokio::spawn(async move { this.run_pump(PumpInit::Resume(Box::new(streaming))).await });
         }
@@ -403,22 +461,27 @@ impl WriteBatcher {
             let next = tokio::time::timeout(self.deps.request_timeout, streaming.next()).await;
             let response = match next {
                 // No response within the request timeout while batches are in
-                // flight: the stream is wedged.
-                Err(_) => return self.pump_died(OxiaError::Timeout),
+                // flight: the stream is wedged. Not retried — the batch may
+                // have been applied.
+                Err(_) => return self.pump_died(OxiaError::Timeout.into()),
                 Ok(None) => {
-                    return self.pump_died(OxiaError::Disconnected(
-                        "write stream closed by server".to_string(),
-                    ));
+                    return self.pump_died(
+                        OxiaError::Disconnected("write stream closed by server".to_string()).into(),
+                    );
                 }
-                Ok(Some(Err(status))) => return self.pump_died(OxiaError::from(status)),
+                Ok(Some(Err(status))) => return self.pump_died(decode_status(status)),
                 Ok(Some(Ok(response))) => response,
             };
 
             let mut st = self.state.lock().expect("write batcher poisoned");
-            let Some(callbacks) = st.pending.pop_front() else {
+            // A response confirms the current leader and a healthy stream.
+            st.failure_streak = 0;
+            st.hint = None;
+            let Some(inflight) = st.pending.pop_front() else {
                 warn!(shard = self.shard, "unexpected write response; ignoring");
                 continue;
             };
+            let callbacks = inflight.callbacks;
             // Release the window slot before completing callbacks, so the
             // next batch is on the wire first.
             self.fill_capacity(&mut st);
@@ -426,7 +489,7 @@ impl WriteBatcher {
                 // Shard idle: park the response stream and exit.
                 st.parked = Some(streaming);
                 st.pump_running = false;
-                let drained = st.queues.closed && st.queues.is_drained();
+                let drained = st.queues.closed && self.is_drained(&st);
                 drop(st);
                 callbacks.complete(response);
                 if drained {
@@ -440,29 +503,43 @@ impl WriteBatcher {
     }
 
     /// Opens the shard's write-stream RPC, feeding it the already-queued
-    /// requests in `rx`.
+    /// requests in `rx`. A leader hint from the previous failure, when present
+    /// for this shard, overrides the (possibly stale) shard-manager leader.
     async fn connect_stream(
         &self,
         rx: UnboundedReceiver<proto::WriteRequest>,
-    ) -> Result<Streaming<proto::WriteResponse>, OxiaError> {
-        let leader = self
-            .deps
-            .shard_manager
-            .get_leader(self.shard)
-            .ok_or(OxiaError::LeaderNotFound { shard: self.shard })?;
+    ) -> Result<Streaming<proto::WriteResponse>, DecodedStatus> {
+        let hinted = {
+            let st = self.state.lock().expect("write batcher poisoned");
+            st.hint
+                .as_ref()
+                .and_then(|hint| hint.address_for(self.shard).map(str::to_string))
+        };
+        let target = match hinted {
+            Some(address) => ensure_protocol(address),
+            None => {
+                self.deps
+                    .shard_manager
+                    .get_leader(self.shard)
+                    .ok_or_else(|| {
+                        DecodedStatus::from(OxiaError::LeaderNotFound { shard: self.shard })
+                    })?
+                    .service_address
+            }
+        };
         let mut provider = self
             .deps
             .provider_manager
-            .get_provider(leader.service_address)
-            .await?;
+            .get_provider(target)
+            .await
+            .map_err(DecodedStatus::from)?;
         let mut request = tonic::Request::new(UnboundedReceiverStream::new(rx));
         let metadata = request.metadata_mut();
         metadata.insert(
             WRITE_STREAM_HEADER_NAMESPACE,
-            self.deps
-                .namespace
-                .parse()
-                .map_err(|_| OxiaError::InvalidArgument("namespace".to_string()))?,
+            self.deps.namespace.parse().map_err(|_| {
+                DecodedStatus::from(OxiaError::InvalidArgument("namespace".to_string()))
+            })?,
         );
         metadata.insert(
             WRITE_STREAM_HEADER_SHARD_ID,
@@ -471,35 +548,77 @@ impl WriteBatcher {
                 .parse()
                 .expect("shard id is valid metadata"),
         );
-        Ok(provider.write_stream(request).await?.into_inner())
+        match provider.write_stream(request).await {
+            Ok(response) => Ok(response.into_inner()),
+            Err(status) => Err(decode_status(status)),
+        }
     }
 
-    /// The stream failed (or could not be created): fail every in-flight
-    /// batch, drop the stream so the next dispatch creates a fresh one, and
-    /// redispatch what is still queued.
-    fn pump_died(self: &Arc<Self>, err: OxiaError) {
-        warn!(shard = self.shard, error = %err, "write stream failed");
-        let (failed, drained) = {
+    /// The stream failed (or could not be created). Retryable failures requeue
+    /// the in-flight batches (they re-send on a fresh stream after a backoff,
+    /// steered by the leader hint when one was attached); everything else, and
+    /// batches older than the request timeout, fail. Retrying re-sends batches
+    /// whose fate is unknown, so unconditional writes may apply more than once
+    /// — the same at-least-once semantics as the reference clients.
+    fn pump_died(self: &Arc<Self>, decoded: DecodedStatus) {
+        let DecodedStatus { error, leader_hint } = decoded;
+        warn!(shard = self.shard, error = %error, "write stream failed");
+        let (expired, failed, drained) = {
             let mut st = self.state.lock().expect("write batcher poisoned");
             st.pump_running = false;
             st.stream_tx = None;
             st.parked = None;
-            let failed: Vec<WriteCallbacks> = st.pending.drain(..).collect();
-            // Queued batches get a fresh stream; each batch fails at most once.
-            self.fill_capacity(&mut st);
-            let drained = st.queues.closed && st.queues.is_drained() && st.pending.is_empty();
-            (failed, drained)
+            if let Some(hint) = leader_hint {
+                st.hint = Some(hint);
+            }
+            let mut expired: Vec<WriteCallbacks> = Vec::new();
+            let mut failed: Vec<WriteCallbacks> = Vec::new();
+            if error.is_retryable() && !st.queues.closed {
+                st.failure_streak += 1;
+                // Requeue in dispatch order ahead of previously-requeued
+                // batches (which are newer), dropping the ones out of time.
+                let mut still: VecDeque<InFlightWrite> = VecDeque::new();
+                for inflight in st.pending.drain(..) {
+                    if inflight.first_dispatch.elapsed() >= self.deps.request_timeout {
+                        expired.push(inflight.callbacks);
+                    } else {
+                        still.push_back(inflight);
+                    }
+                }
+                still.append(&mut st.retry);
+                st.retry = still;
+                // Hold dispatch until the backoff elapses, then reconnect.
+                st.reconnecting = true;
+                let delay = retry_delay(st.failure_streak - 1);
+                let this = self.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(delay).await;
+                    let mut st = this.state.lock().expect("write batcher poisoned");
+                    st.reconnecting = false;
+                    this.fill_capacity(&mut st);
+                });
+            } else {
+                failed = st.pending.drain(..).map(|i| i.callbacks).collect();
+                // Queued batches still get a fresh stream; each batch fails at
+                // most once.
+                self.fill_capacity(&mut st);
+            }
+            let drained = st.queues.closed && self.is_drained(&st);
+            (expired, failed, drained)
         };
+        for callbacks in expired {
+            callbacks.fail(&OxiaError::Timeout);
+        }
         for callbacks in failed {
-            callbacks.fail(&err);
+            callbacks.fail(&error);
         }
         if drained {
             self.drained.notify_waiters();
         }
     }
 
-    fn is_drained(&self, st: &MutexGuard<'_, WriteState>) -> bool {
-        st.queues.is_drained() && st.pending.is_empty()
+    fn is_drained(&self, st: &WriteState) -> bool {
+        st.queues.is_drained() && st.pending.is_empty() && st.retry.is_empty()
     }
 
     /// Flushes everything queued and waits (bounded) for in-flight batches to
@@ -509,8 +628,12 @@ impl WriteBatcher {
         {
             let mut st = self.state.lock().expect("write batcher poisoned");
             st.queues.closed = true;
-            // Drain fast: dispatch everything, ignoring the window bound (the
-            // stream ordering guarantee is unaffected).
+            // Drain fast: cancel any reconnect hold and dispatch everything,
+            // ignoring the window bound (stream ordering is unaffected).
+            st.reconnecting = false;
+            while let Some(inflight) = st.retry.pop_front() {
+                self.send_locked(&mut st, inflight);
+            }
             while let Some(body) = st.queues.take_next() {
                 self.dispatch_locked(&mut st, body);
             }
@@ -527,7 +650,10 @@ impl WriteBatcher {
             if tokio::time::timeout_at(deadline, notified).await.is_err() {
                 let leftovers: Vec<WriteCallbacks> = {
                     let mut st = self.state.lock().expect("write batcher poisoned");
-                    st.pending.drain(..).collect()
+                    let mut leftovers: Vec<WriteCallbacks> =
+                        st.pending.drain(..).map(|i| i.callbacks).collect();
+                    leftovers.extend(st.retry.drain(..).map(|i| i.callbacks));
+                    leftovers
                 };
                 for callbacks in leftovers {
                     callbacks.fail(&OxiaError::Closed);
@@ -659,6 +785,9 @@ impl ReadBatcher {
         });
     }
 
+    /// Executes one read batch, retrying retryable failures with backoff and
+    /// leader hints until the request timeout. Responses are collected before
+    /// any callback completes, so a retried attempt never double-completes.
     async fn send_batch(&self, body: ReadBody) {
         let (requests, callbacks): (Vec<_>, Vec<_>) = body
             .gets
@@ -666,34 +795,78 @@ impl ReadBatcher {
             .map(|p| (p.request, p.callback))
             .unzip();
 
-        let leader = match self.deps.shard_manager.get_leader(self.shard) {
-            Some(node) => node,
+        let deadline = Instant::now() + self.deps.request_timeout;
+        let mut hint: Option<LeaderHint> = None;
+        let mut attempt: u32 = 0;
+        loop {
+            match self.attempt_read(&requests, hint.as_ref()).await {
+                Ok(responses) => {
+                    complete_all(callbacks, responses, "get");
+                    return;
+                }
+                Err(decoded) => {
+                    if decoded.leader_hint.is_some() {
+                        hint = decoded.leader_hint;
+                    }
+                    let delay = retry_delay(attempt);
+                    attempt += 1;
+                    if !decoded.error.is_retryable() || Instant::now() + delay >= deadline {
+                        fail_all(callbacks, &decoded.error);
+                        return;
+                    }
+                    warn!(
+                        shard = self.shard,
+                        error = %decoded.error,
+                        "read batch failed, retrying in {delay:?}"
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+
+    /// One attempt: resolve the target (hint first), issue the RPC, and
+    /// collect every response before completing anything.
+    async fn attempt_read(
+        &self,
+        requests: &[proto::GetRequest],
+        hint: Option<&LeaderHint>,
+    ) -> Result<Vec<proto::GetResponse>, DecodedStatus> {
+        let target = match hint.and_then(|h| h.address_for(self.shard)) {
+            Some(address) => ensure_protocol(address.to_string()),
             None => {
-                fail_all(callbacks, &OxiaError::LeaderNotFound { shard: self.shard });
-                return;
+                self.deps
+                    .shard_manager
+                    .get_leader(self.shard)
+                    .ok_or_else(|| {
+                        DecodedStatus::from(OxiaError::LeaderNotFound { shard: self.shard })
+                    })?
+                    .service_address
             }
         };
-        let mut provider = match self
+        let mut provider = self
             .deps
             .provider_manager
-            .get_provider(leader.service_address)
+            .get_provider(target)
             .await
-        {
-            Ok(provider) => provider,
-            Err(err) => {
-                fail_all(callbacks, &err);
-                return;
-            }
-        };
+            .map_err(DecodedStatus::from)?;
         let mut request = tonic::Request::new(proto::ReadRequest {
             shard: Some(self.shard),
-            gets: requests,
+            gets: requests.to_vec(),
         });
         request.set_timeout(self.deps.request_timeout);
-        match provider.read(request).await {
-            Ok(response) => receive_all(response.into_inner(), callbacks).await,
-            Err(status) => fail_all(callbacks, &OxiaError::from(status)),
+        let mut streaming = match provider.read(request).await {
+            Ok(response) => response.into_inner(),
+            Err(status) => return Err(decode_status(status)),
+        };
+        let mut responses = Vec::with_capacity(requests.len());
+        while let Some(next) = streaming.next().await {
+            match next {
+                Ok(read_response) => responses.extend(read_response.gets),
+                Err(status) => return Err(decode_status(status)),
+            }
         }
+        Ok(responses)
     }
 
     /// Flushes everything queued and waits (bounded) for in-flight reads.
@@ -721,40 +894,6 @@ impl ReadBatcher {
         }
         Ok(())
     }
-}
-
-/// Completes get callbacks in order from a `Read` RPC's response stream.
-async fn receive_all(
-    mut streaming: Streaming<proto::ReadResponse>,
-    callbacks: Vec<oneshot::Sender<Result<proto::GetResponse, OxiaError>>>,
-) {
-    let mut callbacks = callbacks.into_iter();
-    while let Some(next) = streaming.next().await {
-        match next {
-            Ok(read_response) => {
-                for get_response in read_response.gets {
-                    match callbacks.next() {
-                        Some(callback) => {
-                            let _ = callback.send(Ok(get_response));
-                        }
-                        None => {
-                            warn!("server returned more get responses than requested");
-                            return;
-                        }
-                    }
-                }
-            }
-            Err(status) => {
-                fail_all(callbacks, &OxiaError::from(status));
-                return;
-            }
-        }
-    }
-    // The stream ended before every get was answered.
-    fail_all(
-        callbacks,
-        &OxiaError::Decode("missing get response from server".to_string()),
-    );
 }
 
 /// Creates a `Pending` write op and its receiver in one step.

--- a/oxia-client/src/client.rs
+++ b/oxia-client/src/client.rs
@@ -12,7 +12,9 @@ use crate::requests::{
     DeleteBuilder, DeleteRangeBuilder, GetBuilder, ListBuilder, NotificationsBuilder, PutBuilder,
     RangeScanBuilder, SequenceUpdatesBuilder,
 };
+use crate::retry::retry_delay;
 use crate::sequence_updates_manager::SequenceUpdatesManager;
+use crate::server_error::{DecodedStatus, LeaderHint, decode_status};
 use crate::session_manager::SessionManager;
 use crate::shard_manager::{ShardManager, ShardManagerOptions};
 use crate::streams::{
@@ -668,18 +670,29 @@ impl OxiaClient {
         self.ensure_open()?;
         let opens = self.target_shards(partition_key)?.into_iter().map(|shard| {
             let client = self.clone();
-            let mut request = request.clone();
+            let request = request.clone();
             async move {
-                request.shard = Some(shard);
-                let mut provider = client.leader_provider(shard).await?;
-                let streaming = provider.list(request).await?.into_inner();
+                let (first, streaming) = client
+                    .open_streaming_with_retry(shard, move |mut provider| {
+                        let mut request = request.clone();
+                        request.shard = Some(shard);
+                        async move { provider.list(request).await }
+                    })
+                    .await?;
+                let head = first
+                    .map(|response: proto::ListResponse| {
+                        response.keys.into_iter().map(Ok).collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
                 let stream: ShardStream<String> = Box::pin(
-                    streaming
-                        .map(|chunk| match chunk {
-                            Ok(response) => response.keys.into_iter().map(Ok).collect(),
-                            Err(status) => vec![Err(OxiaError::from(status))],
-                        })
-                        .flat_map(futures::stream::iter),
+                    futures::stream::iter(head).chain(
+                        streaming
+                            .map(|chunk| match chunk {
+                                Ok(response) => response.keys.into_iter().map(Ok).collect(),
+                                Err(status) => vec![Err(OxiaError::from(status))],
+                            })
+                            .flat_map(futures::stream::iter),
+                    ),
                 );
                 Ok::<_, OxiaError>(stream)
             }
@@ -695,22 +708,32 @@ impl OxiaClient {
         self.ensure_open()?;
         let opens = self.target_shards(partition_key)?.into_iter().map(|shard| {
             let client = self.clone();
-            let mut request = request.clone();
+            let request = request.clone();
             async move {
-                request.shard = Some(shard);
-                let mut provider = client.leader_provider(shard).await?;
-                let streaming = provider.range_scan(request).await?.into_inner();
+                let (first, streaming) = client
+                    .open_streaming_with_retry(shard, move |mut provider| {
+                        let mut request = request.clone();
+                        request.shard = Some(shard);
+                        async move { provider.range_scan(request).await }
+                    })
+                    .await?;
+                let to_items = |response: proto::RangeScanResponse| {
+                    response
+                        .records
+                        .into_iter()
+                        .map(|record| GetResult::from_proto(record, None))
+                        .collect::<Vec<_>>()
+                };
+                let head = first.map(to_items).unwrap_or_default();
                 let stream: ShardStream<GetResult> = Box::pin(
-                    streaming
-                        .map(|chunk| match chunk {
-                            Ok(response) => response
-                                .records
-                                .into_iter()
-                                .map(|record| GetResult::from_proto(record, None))
-                                .collect(),
-                            Err(status) => vec![Err(OxiaError::from(status))],
-                        })
-                        .flat_map(futures::stream::iter),
+                    futures::stream::iter(head).chain(
+                        streaming
+                            .map(move |chunk| match chunk {
+                                Ok(response) => to_items(response),
+                                Err(status) => vec![Err(OxiaError::from(status))],
+                            })
+                            .flat_map(futures::stream::iter),
+                    ),
                 );
                 Ok::<_, OxiaError>(stream)
             }
@@ -718,20 +741,67 @@ impl OxiaClient {
         Ok(RangeScanStream::new(merged(try_join_all(opens).await?)))
     }
 
-    async fn leader_provider(
+    /// Opens a per-shard server stream, retrying — with backoff and leader
+    /// hints, bounded by the request timeout — until the first response (or a
+    /// clean end of stream) has been received. Past that point the caller
+    /// consumes the stream without retries, so results are never duplicated
+    /// (the reference client's "verified" pattern).
+    async fn open_streaming_with_retry<Resp, Fut>(
         &self,
         shard: i64,
-    ) -> Result<proto::oxia_client_client::OxiaClientClient<tonic::transport::Channel>, OxiaError>
+        call: impl Fn(proto::oxia_client_client::OxiaClientClient<tonic::transport::Channel>) -> Fut,
+    ) -> Result<(Option<Resp>, tonic::Streaming<Resp>), OxiaError>
+    where
+        Fut: Future<Output = Result<tonic::Response<tonic::Streaming<Resp>>, tonic::Status>>,
     {
-        let leader = self
-            .inner
-            .shard_manager
-            .get_leader(shard)
-            .ok_or(OxiaError::LeaderNotFound { shard })?;
-        self.inner
-            .provider_manager
-            .get_provider(leader.service_address)
-            .await
+        let deadline = tokio::time::Instant::now() + self.request_timeout();
+        let mut hint: Option<LeaderHint> = None;
+        let mut attempt: u32 = 0;
+        loop {
+            let outcome: Result<_, DecodedStatus> = async {
+                let target = match hint.as_ref().and_then(|h| h.address_for(shard)) {
+                    Some(address) => crate::address::ensure_protocol(address.to_string()),
+                    None => {
+                        self.inner
+                            .shard_manager
+                            .get_leader(shard)
+                            .ok_or_else(|| {
+                                DecodedStatus::from(OxiaError::LeaderNotFound { shard })
+                            })?
+                            .service_address
+                    }
+                };
+                let provider = self
+                    .inner
+                    .provider_manager
+                    .get_provider(target)
+                    .await
+                    .map_err(DecodedStatus::from)?;
+                let mut streaming = call(provider).await.map_err(decode_status)?.into_inner();
+                match streaming.next().await {
+                    Some(Ok(first)) => Ok((Some(first), streaming)),
+                    None => Ok((None, streaming)),
+                    Some(Err(status)) => Err(decode_status(status)),
+                }
+            }
+            .await;
+            match outcome {
+                Ok(opened) => return Ok(opened),
+                Err(decoded) => {
+                    if decoded.leader_hint.is_some() {
+                        hint = decoded.leader_hint;
+                    }
+                    let delay = retry_delay(attempt);
+                    attempt += 1;
+                    if !decoded.error.is_retryable()
+                        || tokio::time::Instant::now() + delay >= deadline
+                    {
+                        return Err(decoded.error);
+                    }
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
     }
 
     pub(crate) async fn open_notifications(

--- a/oxia-client/src/errors.rs
+++ b/oxia-client/src/errors.rs
@@ -100,16 +100,25 @@ impl OxiaError {
     /// Whether retrying the operation that produced this error might succeed.
     ///
     /// Mirrors the retryable set of the reference Go client: connection loss,
-    /// missing shard leaders / assignments, and the `UNAVAILABLE` / `ABORTED`
-    /// gRPC codes. Semantic results (e.g. [`KeyNotFound`](OxiaError::KeyNotFound))
-    /// and terminal failures are not retryable.
+    /// missing shard leaders / assignments, and the `UNAVAILABLE` / `ABORTED` /
+    /// `CANCELLED` gRPC codes (the last being a shutting-down server's own
+    /// cancellation propagating). Semantic results (e.g.
+    /// [`KeyNotFound`](OxiaError::KeyNotFound)) and terminal failures are not
+    /// retryable.
     pub fn is_retryable(&self) -> bool {
         match self {
             OxiaError::LeaderNotFound { .. }
             | OxiaError::NoShardForKey { .. }
             | OxiaError::Disconnected(_) => true,
             OxiaError::Grpc { code, .. } => {
-                matches!(code, tonic::Code::Unavailable | tonic::Code::Aborted)
+                // `Cancelled` here is the *server's* context cancellation
+                // propagating while it shuts down or drops a connection — the
+                // client never cancels these RPCs itself — so like the other
+                // two it signals a server that may come right back.
+                matches!(
+                    code,
+                    tonic::Code::Unavailable | tonic::Code::Aborted | tonic::Code::Cancelled
+                )
             }
             _ => false,
         }
@@ -118,6 +127,14 @@ impl OxiaError {
 
 impl From<tonic::Status> for OxiaError {
     fn from(status: tonic::Status) -> Self {
+        // tonic reports client-side transport failures (broken connection,
+        // h2 errors) as code `Unknown` with a local error source, unlike
+        // grpc-go which uses `Unavailable` for the same events. A status the
+        // *server* sent has no local source. Map the transport case to
+        // `Disconnected` so it classifies as retryable, like in Go.
+        if status.code() == tonic::Code::Unknown && std::error::Error::source(&status).is_some() {
+            return OxiaError::Disconnected(format!("transport error: {}", status.message()));
+        }
         OxiaError::Grpc {
             code: status.code(),
             message: status.message().to_string(),
@@ -151,6 +168,13 @@ mod tests {
         assert!(
             OxiaError::Grpc {
                 code: tonic::Code::Aborted,
+                message: msg.clone(),
+            }
+            .is_retryable()
+        );
+        assert!(
+            OxiaError::Grpc {
+                code: tonic::Code::Cancelled,
                 message: msg.clone(),
             }
             .is_retryable()

--- a/oxia-client/src/lib.rs
+++ b/oxia-client/src/lib.rs
@@ -63,6 +63,14 @@
 //! version condition) with application-level judgment. Each operation on
 //! [`OxiaClient`] documents the errors it can produce.
 //!
+//! The client retries retryable failures internally — re-routing via the
+//! leader hints the server attaches to routing errors, with exponential
+//! backoff, bounded by the request timeout — so the errors you observe are
+//! post-retry. One consequence, shared with the reference clients: a write
+//! whose batch failed *after* reaching the wire may be retried even though the
+//! server already applied it, so unconditional writes have at-least-once
+//! semantics under retries; version-conditioned writes are exactly-once.
+//!
 //! # Cancellation
 //!
 //! Dropping an operation's future stops waiting but does not recall an
@@ -88,9 +96,9 @@ mod provider_manager;
 mod requests;
 mod retry;
 mod sequence_updates_manager;
+mod server_error;
 mod session_manager;
 mod shard_manager;
-mod status;
 mod streams;
 mod types;
 

--- a/oxia-client/src/retry.rs
+++ b/oxia-client/src/retry.rs
@@ -20,6 +20,18 @@ const MAX_DELAY: Duration = Duration::from_secs(30);
 /// backoff, so long-lived streams reconnect quickly after an occasional error.
 const RESET_AFTER: Duration = Duration::from_secs(10);
 
+/// Backoff for operation-level retries (failed batches, stream opens).
+/// Attempts are bounded by the request timeout, so the cap stays low.
+const OP_RETRY_INITIAL_DELAY: Duration = Duration::from_millis(100);
+const OP_RETRY_MAX_DELAY: Duration = Duration::from_secs(5);
+
+/// The delay before retry `attempt` (0-based) of a failed operation.
+pub(crate) fn retry_delay(attempt: u32) -> Duration {
+    OP_RETRY_INITIAL_DELAY
+        .saturating_mul(1u32 << attempt.min(16))
+        .min(OP_RETRY_MAX_DELAY)
+}
+
 /// The failure mode of a single attempt of a retried operation.
 pub(crate) enum RetryError {
     /// A transient failure; retry after a backoff delay.

--- a/oxia-client/src/server_error.rs
+++ b/oxia-client/src/server_error.rs
@@ -1,0 +1,150 @@
+//! Decoding of Oxia's rich gRPC error details.
+//!
+//! The server attaches a `google.rpc.ErrorInfo` (domain `oxia.io`) to error
+//! statuses, carrying a machine-readable `reason` and, for routing errors, a
+//! **leader hint** (`shard` / `leader` metadata) pointing at the current
+//! leader before the client's shard-assignment watcher has caught up. This
+//! mirrors the reference Go client's `constant.FromGrpcError`.
+
+use crate::errors::OxiaError;
+use tonic::Status;
+use tonic_types::StatusExt;
+
+const OXIA_ERROR_DOMAIN: &str = "oxia.io";
+const METADATA_SHARD: &str = "shard";
+const METADATA_LEADER: &str = "leader";
+const REASON_SESSION_NOT_FOUND: &str = "SESSION_NOT_FOUND";
+
+/// The address of a shard's current leader, extracted from an error's details.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LeaderHint {
+    pub(crate) shard: i64,
+    pub(crate) leader: String,
+}
+
+impl LeaderHint {
+    /// The hinted address, if this hint is for `shard`.
+    pub(crate) fn address_for(&self, shard: i64) -> Option<&str> {
+        (self.shard == shard).then_some(self.leader.as_str())
+    }
+}
+
+/// A gRPC status decoded into a typed error plus an optional leader hint.
+pub(crate) struct DecodedStatus {
+    pub(crate) error: OxiaError,
+    pub(crate) leader_hint: Option<LeaderHint>,
+}
+
+impl From<OxiaError> for DecodedStatus {
+    fn from(error: OxiaError) -> Self {
+        DecodedStatus {
+            error,
+            leader_hint: None,
+        }
+    }
+}
+
+/// Decodes `status`, honoring Oxia's `ErrorInfo` details when present.
+pub(crate) fn decode_status(status: Status) -> DecodedStatus {
+    let details = status.get_error_details();
+    let Some(info) = details.error_info() else {
+        return DecodedStatus {
+            error: OxiaError::from(status),
+            leader_hint: None,
+        };
+    };
+    if info.domain != OXIA_ERROR_DOMAIN {
+        return DecodedStatus {
+            error: OxiaError::from(status),
+            leader_hint: None,
+        };
+    }
+
+    let leader_hint = match (
+        info.metadata.get(METADATA_LEADER),
+        info.metadata.get(METADATA_SHARD),
+    ) {
+        (Some(leader), Some(shard)) if !leader.is_empty() => {
+            shard.parse().ok().map(|shard| LeaderHint {
+                shard,
+                leader: leader.clone(),
+            })
+        }
+        _ => None,
+    };
+
+    let error = match info.reason.as_str() {
+        REASON_SESSION_NOT_FOUND => OxiaError::SessionExpired,
+        _ => OxiaError::from(status),
+    };
+
+    DecodedStatus { error, leader_hint }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use tonic::Code;
+    use tonic_types::ErrorDetails;
+
+    fn oxia_status(code: Code, reason: &str, metadata: HashMap<String, String>) -> Status {
+        let mut details = ErrorDetails::new();
+        details.set_error_info(reason, OXIA_ERROR_DOMAIN, metadata);
+        Status::with_error_details(code, "test", details)
+    }
+
+    #[test]
+    fn plain_status_decodes_by_code() {
+        let decoded = decode_status(Status::unavailable("down"));
+        assert!(matches!(
+            decoded.error,
+            OxiaError::Grpc {
+                code: Code::Unavailable,
+                ..
+            }
+        ));
+        assert!(decoded.error.is_retryable());
+        assert!(decoded.leader_hint.is_none());
+    }
+
+    #[test]
+    fn session_not_found_reason_maps_to_session_expired() {
+        let status = oxia_status(Code::NotFound, REASON_SESSION_NOT_FOUND, HashMap::new());
+        let decoded = decode_status(status);
+        assert!(matches!(decoded.error, OxiaError::SessionExpired));
+    }
+
+    #[test]
+    fn leader_hint_is_extracted() {
+        let metadata = HashMap::from([
+            ("shard".to_string(), "7".to_string()),
+            ("leader".to_string(), "server-2:6648".to_string()),
+        ]);
+        let status = oxia_status(Code::Aborted, "NODE_IS_NOT_LEADER", metadata);
+        let decoded = decode_status(status);
+        assert!(decoded.error.is_retryable());
+        let hint = decoded.leader_hint.expect("hint");
+        assert_eq!(hint.shard, 7);
+        assert_eq!(hint.leader, "server-2:6648");
+        assert_eq!(hint.address_for(7), Some("server-2:6648"));
+        assert_eq!(hint.address_for(8), None);
+    }
+
+    #[test]
+    fn foreign_domain_details_are_ignored() {
+        let mut details = ErrorDetails::new();
+        details.set_error_info("SESSION_NOT_FOUND", "example.com", HashMap::new());
+        let status = Status::with_error_details(Code::NotFound, "test", details);
+        let decoded = decode_status(status);
+        assert!(matches!(decoded.error, OxiaError::Grpc { .. }));
+        assert!(decoded.leader_hint.is_none());
+    }
+
+    #[test]
+    fn incomplete_hint_metadata_is_ignored() {
+        let metadata = HashMap::from([("leader".to_string(), "server-2:6648".to_string())]);
+        let status = oxia_status(Code::Aborted, "NODE_IS_NOT_LEADER", metadata);
+        assert!(decode_status(status).leader_hint.is_none());
+    }
+}

--- a/oxia-client/src/session_manager.rs
+++ b/oxia-client/src/session_manager.rs
@@ -2,8 +2,8 @@ use crate::errors::OxiaError;
 use crate::proto::{CloseSessionRequest, CreateSessionRequest, SessionHeartbeat};
 use crate::provider_manager::ProviderManager;
 use crate::retry::{RetryError, retry_until_cancelled};
+use crate::server_error::decode_status;
 use crate::shard_manager::ShardManager;
-use crate::status::CODE_SESSION_NOT_FOUND;
 use dashmap::DashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -123,13 +123,16 @@ async fn start_keep_alive(
                                 heartbeat.set_timeout(request_timeout);
                                 if let Err(err) = provider.keep_alive(heartbeat).await
                                 {
-                                    if err.code() as i32 == CODE_SESSION_NOT_FOUND {
+                                    // The server reports an expired session as
+                                    // NotFound with ErrorInfo reason SESSION_NOT_FOUND.
+                                    let decoded = decode_status(err);
+                                    if matches!(decoded.error, OxiaError::SessionExpired) {
                                         info!("Session {session_id} on shard {shard_id} expired; it will be re-created on next use.");
                                         // Mark dead so get_session_id re-creates it, then stop.
                                         local_alive.store(false, Ordering::Release);
                                         return Err(RetryError::fatal(OxiaError::SessionExpired));
                                     }
-                                    return Err(RetryError::transient(OxiaError::from(err)));
+                                    return Err(RetryError::transient(decoded.error));
                                 }
                             }
                         }

--- a/oxia-client/src/status.rs
+++ b/oxia-client/src/status.rs
@@ -1,1 +1,0 @@
-pub const CODE_SESSION_NOT_FOUND: i32 = 108;

--- a/oxia-client/tests/integration_tests.rs
+++ b/oxia-client/tests/integration_tests.rs
@@ -21,10 +21,17 @@ async fn start_oxia() -> (ContainerAsync<GenericImage>, String) {
         .await
         .expect("Failed to start Oxia container");
 
-    let host_port = container
-        .get_host_port_ipv4(OXIA_PORT)
-        .await
-        .expect("Failed to get host port");
+    // Under heavy parallel container churn, docker inspect can briefly race
+    // the port mapping; retry a few times before giving up.
+    let mut host_port = container.get_host_port_ipv4(OXIA_PORT).await;
+    for _ in 0..20 {
+        if host_port.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        host_port = container.get_host_port_ipv4(OXIA_PORT).await;
+    }
+    let host_port = host_port.expect("Failed to get host port");
 
     let address = format!("http://127.0.0.1:{}", host_port);
     (container, address)
@@ -1746,5 +1753,73 @@ async fn test_adaptive_window_of_one_under_concurrency() {
         let got = get.await.unwrap();
         assert_eq!(got.value.as_deref(), Some(format!("v{i}").as_bytes()));
     }
+    client.close().await.unwrap();
+}
+
+// ============================================================
+// Retry / Outage Tests (P1-11)
+// ============================================================
+
+/// Starts Oxia on a host port that stays stable across container
+/// stop/start. Docker re-assigns ephemeral (`-P`) host ports on restart, so
+/// the restart test must pin one — like any real deployment, where an
+/// endpoint keeps its address across restarts.
+async fn start_oxia_fixed_port() -> (ContainerAsync<GenericImage>, String) {
+    let image = std::env::var("OXIA_IMAGE").unwrap_or_else(|_| DEFAULT_OXIA_IMAGE.to_string());
+    let tag = std::env::var("OXIA_TAG").unwrap_or_else(|_| DEFAULT_OXIA_TAG.to_string());
+
+    // Grab a free host port and release it just before the container binds it.
+    let host_port = std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+
+    let container = GenericImage::new(image, tag)
+        .with_wait_for(WaitFor::message_on_stdout("Started Grpc server"))
+        .with_mapped_port(host_port, ContainerPort::Tcp(OXIA_PORT))
+        .with_cmd(vec!["oxia", "standalone"])
+        .start()
+        .await
+        .expect("Failed to start Oxia container");
+
+    let address = format!("http://127.0.0.1:{}", host_port);
+    (container, address)
+}
+
+/// Operations issued while the server is down must ride through the outage on
+/// the client's internal retries and complete once the server is back.
+#[tokio::test]
+async fn test_operations_survive_server_restart() {
+    let (container, address) = start_oxia_fixed_port().await;
+    let client = OxiaClientBuilder::new()
+        .service_address(address)
+        .request_timeout(Duration::from_secs(60))
+        .build()
+        .await
+        .unwrap();
+
+    client.put("outage/before", b"v1".to_vec()).await.unwrap();
+
+    container.stop().await.expect("stop oxia");
+    let restarter = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        container.start().await.expect("restart oxia");
+        container
+    });
+
+    // Issued against a stopped server: the write batcher must retry (fresh
+    // stream + backoff) until the server returns.
+    client.put("outage/during", b"v2".to_vec()).await.unwrap();
+
+    // Reads retry through their own path.
+    let got = client.get("outage/during").await.unwrap();
+    assert_eq!(got.value.as_deref(), Some(b"v2".as_ref()));
+
+    // List/scan opens retry too.
+    let keys = client.list("outage/", "outage/~").await.unwrap();
+    assert!(keys.contains(&"outage/during".to_string()));
+
+    let _container = restarter.await.unwrap();
     client.close().await.unwrap();
 }


### PR DESCRIPTION
Ports Go's `executeWithRetry` semantics onto the adaptive-batching architecture from #37. Data-path operations now ride out leader elections, server restarts, and dropped connections instead of surfacing them — retried with exponential backoff (100 ms → 5 s), bounded by the request timeout, and **re-routed via the leader hints** the server attaches to routing errors.

## The pieces

**`server_error.rs`** — decodes the `google.rpc.ErrorInfo` (domain `oxia.io`) from statuses via `tonic-types`: the machine-readable `reason`, and the **leader hint** (`shard`/`leader` metadata, same keys as Go's `constant.ErrorMetadata`). A hint steers the next attempt's target — exactly Go's `getTargetByShard` — until a successful response confirms the leader.

**Writes** — in-flight batches now retain their wire request (`Bytes`-refcounted, no copies). On a retryable stream failure the pump *requeues* them ahead of newer queued batches (submission order preserved — same single-mutex guarantee as #37), holds dispatch through a backoff so a dead leader isn't hammered, and the next stream connect targets the hinted leader. Batches older than the request timeout fail with `Timeout`. Go-faithful consequence, now documented in the crate docs: a batch whose fate is unknown is re-sent, so **unconditional writes are at-least-once under retries** (conditional writes stay exactly-once).

**Reads** — attempts collect every response before completing any callback (Go's `ExecuteRead` shape), so whole-batch retry can never double-complete. Hint-aware targeting per attempt.

**List/RangeScan** — per-shard streams retry the open **until the first response is received** (Go's `verified` pattern), then propagate errors; results can never be duplicated.

## Two real bugs the work uncovered

1. **Session expiry was undetectable.** Keep-alive compared tonic codes against legacy custom code `108` — no tonic code can ever equal 108. The server actually reports `NotFound` + `ErrorInfo` reason `SESSION_NOT_FOUND` (as Go's `sessions.go` expects). Detection now uses the decoded reason; `status.rs` deleted.
2. **Transport failures were non-retryable.** tonic reports client-side connection breakage as code `Unknown` with a local error `source()` — where grpc-go reports `Unavailable`. Those now map to `Disconnected` (server-sent `Unknown`, which has no local source, keeps failing fast). A shutting-down server's propagated `Cancelled` is also classified retryable — our client never cancels these RPCs itself.

## The test that caught them

`test_operations_survive_server_restart`: stops the container mid-traffic, issues put/get/list against the dead server, restarts it 3 s later, and requires everything to complete. Both classification bugs above were found live by this test (first as an instant `Cancelled` failure, then as `Unknown "transport error"`). It runs on a **pinned host port** — the debugging detour worth knowing about: Docker re-assigns ephemeral host ports across `stop`/`start`, so under parallel churn the "outage" never ended on the old port; the client was retrying correctly the whole time. Real deployments keep stable endpoints, so the pin matches reality.

## Verification

fmt / clippy `-D warnings` / `cargo doc` clean · **39 unit** (5 new decode/hint tests, updated classification tests) · **12 doc** · **50 integration** (restart test new) · **2 interop** — full suites green **twice in a row under `--test-threads=4`**. Session-recreation and all batching tests unaffected.

Next: P1-12 (re-route batches on shard split/merge) builds directly on the requeue machinery added here.