### PR TITLE
feat: re-route operations across shard splits and merges (P1-12)

### DIFF
--- a/oxia-client/src/batcher.rs
+++ b/oxia-client/src/batcher.rs
@@ -278,6 +278,16 @@ struct WriteState {
 }
 
 /// Batches write operations for one shard.
+/// Whether `shard` still exists; if not, an op targeting it must re-route.
+fn absent_shard_error(deps: &BatcherDeps, shard: i64) -> OxiaError {
+    if deps.shard_manager.shard_exists(shard) {
+        OxiaError::LeaderNotFound { shard }
+    } else {
+        // Split or merged away: the operation builders re-route to the new shard.
+        OxiaError::ShardMoved
+    }
+}
+
 pub(crate) struct WriteBatcher {
     shard: i64,
     deps: Arc<BatcherDeps>,
@@ -521,9 +531,7 @@ impl WriteBatcher {
                 self.deps
                     .shard_manager
                     .get_leader(self.shard)
-                    .ok_or_else(|| {
-                        DecodedStatus::from(OxiaError::LeaderNotFound { shard: self.shard })
-                    })?
+                    .ok_or_else(|| DecodedStatus::from(absent_shard_error(&self.deps, self.shard)))?
                     .service_address
             }
         };
@@ -573,7 +581,11 @@ impl WriteBatcher {
             }
             let mut expired: Vec<WriteCallbacks> = Vec::new();
             let mut failed: Vec<WriteCallbacks> = Vec::new();
-            if error.is_retryable() && !st.queues.closed {
+            // A split/merged shard is retryable-by-rerouting, not by re-sending
+            // to the same (now dead) shard: let it fall through to fail so the
+            // builders re-route.
+            if error.is_retryable() && !matches!(error, OxiaError::ShardMoved) && !st.queues.closed
+            {
                 st.failure_streak += 1;
                 // Requeue in dispatch order ahead of previously-requeued
                 // batches (which are newer), dropping the ones out of time.
@@ -810,7 +822,10 @@ impl ReadBatcher {
                     }
                     let delay = retry_delay(attempt);
                     attempt += 1;
-                    if !decoded.error.is_retryable() || Instant::now() + delay >= deadline {
+                    if !decoded.error.is_retryable()
+                        || matches!(decoded.error, OxiaError::ShardMoved)
+                        || Instant::now() + delay >= deadline
+                    {
                         fail_all(callbacks, &decoded.error);
                         return;
                     }
@@ -838,9 +853,7 @@ impl ReadBatcher {
                 self.deps
                     .shard_manager
                     .get_leader(self.shard)
-                    .ok_or_else(|| {
-                        DecodedStatus::from(OxiaError::LeaderNotFound { shard: self.shard })
-                    })?
+                    .ok_or_else(|| DecodedStatus::from(absent_shard_error(&self.deps, self.shard)))?
                     .service_address
             }
         };

--- a/oxia-client/src/client.rs
+++ b/oxia-client/src/client.rs
@@ -12,7 +12,7 @@ use crate::requests::{
     DeleteBuilder, DeleteRangeBuilder, GetBuilder, ListBuilder, NotificationsBuilder, PutBuilder,
     RangeScanBuilder, SequenceUpdatesBuilder,
 };
-use crate::retry::retry_delay;
+use crate::retry::{retry_delay, retry_until};
 use crate::sequence_updates_manager::SequenceUpdatesManager;
 use crate::server_error::{DecodedStatus, LeaderHint, decode_status};
 use crate::session_manager::SessionManager;
@@ -540,6 +540,47 @@ impl OxiaClient {
         self.inner.session_manager.get_session_id(shard).await
     }
 
+    /// Runs `attempt` against the shard that owns `routing_key`, re-resolving
+    /// the shard and retrying (backoff, bounded by the request timeout) while
+    /// routing is unavailable — `NoShardForKey` (assignments not loaded yet) or
+    /// `ShardMoved` (the shard just split or merged). This is how an operation
+    /// re-routes to the new shard after a split/merge.
+    pub(crate) async fn with_shard_retry<T, F, Fut>(
+        &self,
+        routing_key: &str,
+        attempt: F,
+    ) -> Result<T, OxiaError>
+    where
+        F: Fn(i64) -> Fut,
+        Fut: std::future::Future<Output = Result<T, OxiaError>>,
+    {
+        retry_until(
+            self.request_timeout(),
+            |err| matches!(err, OxiaError::ShardMoved | OxiaError::NoShardForKey { .. }),
+            || async {
+                let shard = self.shard_for(routing_key)?;
+                attempt(shard).await
+            },
+        )
+        .await
+    }
+
+    /// Retries `op` while it fails with `ShardMoved` — for whole-operation
+    /// re-routing (broadcasts) where a single failing shard means the shard set
+    /// changed and the operation must be re-issued against the new set.
+    pub(crate) async fn with_reroute_retry<T, F, Fut>(&self, op: F) -> Result<T, OxiaError>
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = Result<T, OxiaError>>,
+    {
+        retry_until(
+            self.request_timeout(),
+            |err| matches!(err, OxiaError::ShardMoved),
+            op,
+        )
+        .await
+    }
+
     /// Returns (creating on first use) the write batcher for a shard.
     fn write_batcher(&self, shard_id: i64) -> Arc<WriteBatcher> {
         self.inner
@@ -614,43 +655,50 @@ impl OxiaClient {
         request: proto::GetRequest,
         comparison: ComparisonType,
     ) -> Result<GetResult, OxiaError> {
-        let mut join_set = JoinSet::new();
-        for shard in self.inner.shard_manager.get_shard_ids() {
-            let client = self.clone();
+        // Re-issue against the current shard set if a shard splits mid-flight.
+        self.with_reroute_retry(|| {
             let request = request.clone();
-            join_set.spawn(async move {
-                let requested_key = request.key.clone();
-                let response = client.submit_get(shard, request).await?;
-                check_status(response.status)?;
-                GetResult::from_proto(response, Some(requested_key))
-            });
-        }
-        let mut best: Option<GetResult> = None;
-        let mut join_error: Option<OxiaError> = None;
-        while let Some(joined) = join_set.join_next().await {
-            let result = match joined {
-                Ok(result) => result,
-                Err(err) => {
-                    join_error = Some(OxiaError::Disconnected(err.to_string()));
-                    continue;
+            async move {
+                let mut join_set = JoinSet::new();
+                for shard in self.inner.shard_manager.get_shard_ids() {
+                    let client = self.clone();
+                    let request = request.clone();
+                    join_set.spawn(async move {
+                        let requested_key = request.key.clone();
+                        let response = client.submit_get(shard, request).await?;
+                        check_status(response.status)?;
+                        GetResult::from_proto(response, Some(requested_key))
+                    });
                 }
-            };
-            match result {
-                Ok(candidate) => {
-                    best = Some(match best.take() {
-                        None => candidate,
-                        Some(current) => pick_get_winner(current, candidate, comparison),
-                    })
+                let mut best: Option<GetResult> = None;
+                let mut join_error: Option<OxiaError> = None;
+                while let Some(joined) = join_set.join_next().await {
+                    let result = match joined {
+                        Ok(result) => result,
+                        Err(err) => {
+                            join_error = Some(OxiaError::Disconnected(err.to_string()));
+                            continue;
+                        }
+                    };
+                    match result {
+                        Ok(candidate) => {
+                            best = Some(match best.take() {
+                                None => candidate,
+                                Some(current) => pick_get_winner(current, candidate, comparison),
+                            })
+                        }
+                        // Not every shard has a matching record.
+                        Err(OxiaError::KeyNotFound) => {}
+                        Err(err) => return Err(err),
+                    }
                 }
-                // Not every shard has a matching record.
-                Err(OxiaError::KeyNotFound) => {}
-                Err(err) => return Err(err),
+                if let Some(err) = join_error {
+                    return Err(err);
+                }
+                best.ok_or(OxiaError::KeyNotFound)
             }
-        }
-        if let Some(err) = join_error {
-            return Err(err);
-        }
-        best.ok_or(OxiaError::KeyNotFound)
+        })
+        .await
     }
 
     /// Resolves the target shards for a list/scan: either the single shard
@@ -838,26 +886,33 @@ impl OxiaClient {
         Ok(SequenceUpdates::new(rx))
     }
 
-    /// Broadcasts a delete-range to every shard.
+    /// Broadcasts a delete-range to every shard, re-issuing against the current
+    /// shard set if one splits or merges mid-flight (idempotent).
     pub(crate) async fn broadcast_delete_range(
         &self,
         request: proto::DeleteRangeRequest,
     ) -> Result<(), OxiaError> {
-        let mut join_set = JoinSet::new();
-        for shard in self.inner.shard_manager.get_shard_ids() {
-            let client = self.clone();
+        self.with_reroute_retry(|| {
             let request = request.clone();
-            join_set.spawn(async move {
-                let response = client
-                    .submit_write(shard, request, WriteOp::DeleteRange)
-                    .await?;
-                check_status(response.status)
-            });
-        }
-        while let Some(joined) = join_set.join_next().await {
-            joined.map_err(|err| OxiaError::Disconnected(err.to_string()))??;
-        }
-        Ok(())
+            async move {
+                let mut join_set = JoinSet::new();
+                for shard in self.inner.shard_manager.get_shard_ids() {
+                    let client = self.clone();
+                    let request = request.clone();
+                    join_set.spawn(async move {
+                        let response = client
+                            .submit_write(shard, request, WriteOp::DeleteRange)
+                            .await?;
+                        check_status(response.status)
+                    });
+                }
+                while let Some(joined) = join_set.join_next().await {
+                    joined.map_err(|err| OxiaError::Disconnected(err.to_string()))??;
+                }
+                Ok(())
+            }
+        })
+        .await
     }
 }
 

--- a/oxia-client/src/errors.rs
+++ b/oxia-client/src/errors.rs
@@ -91,6 +91,12 @@ pub enum OxiaError {
     #[error("failed to decode server response: {0}")]
     Decode(String),
 
+    /// A shard was split or merged while an operation targeted it. The client
+    /// re-routes such operations to the new shard automatically, so this is not
+    /// normally observed. Retryable (by re-routing).
+    #[error("shard was split or merged")]
+    ShardMoved,
+
     /// The client has been shut down and can no longer be used.
     #[error("client is closed")]
     Closed,
@@ -109,6 +115,7 @@ impl OxiaError {
         match self {
             OxiaError::LeaderNotFound { .. }
             | OxiaError::NoShardForKey { .. }
+            | OxiaError::ShardMoved
             | OxiaError::Disconnected(_) => true,
             OxiaError::Grpc { code, .. } => {
                 // `Cancelled` here is the *server's* context cancellation
@@ -184,6 +191,7 @@ mod tests {
         assert!(!OxiaError::UnexpectedVersionId.is_retryable());
         assert!(!OxiaError::SessionExpired.is_retryable());
         assert!(!OxiaError::RequestTooLarge.is_retryable());
+        assert!(OxiaError::ShardMoved.is_retryable());
         assert!(!OxiaError::Timeout.is_retryable());
         assert!(!OxiaError::Closed.is_retryable());
         assert!(

--- a/oxia-client/src/lib.rs
+++ b/oxia-client/src/lib.rs
@@ -64,7 +64,8 @@
 //! [`OxiaClient`] documents the errors it can produce.
 //!
 //! The client retries retryable failures internally — re-routing via the
-//! leader hints the server attaches to routing errors, with exponential
+//! leader hints the server attaches to routing errors, re-hashing operations
+//! onto the new shard when a shard is split or merged, with exponential
 //! backoff, bounded by the request timeout — so the errors you observe are
 //! post-retry. One consequence, shared with the reference clients: a write
 //! whose batch failed *after* reaching the wire may be retried even though the

--- a/oxia-client/src/requests.rs
+++ b/oxia-client/src/requests.rs
@@ -99,26 +99,55 @@ impl PutBuilder {
     async fn execute(self) -> Result<PutResult, OxiaError> {
         let client = self.client;
         client.ensure_open()?;
-        let routing_key = self.partition_key.as_deref().unwrap_or(&self.key);
-        let shard = client.shard_for(routing_key)?;
-        let session_id = if self.ephemeral {
-            Some(client.session_id_for(shard).await?)
-        } else {
-            None
-        };
-        let request = proto::PutRequest {
-            key: self.key.clone(),
-            value: self.value,
-            expected_version_id: self.expected_version_id,
-            session_id,
-            client_identity: Some(client.identity().to_string()),
-            partition_key: self.partition_key,
-            sequence_key_delta: self.sequence_key_deltas,
-            secondary_indexes: self.secondary_indexes,
-            override_version_id: None,
-            override_modifications_count: None,
-        };
-        let response = client.submit_write(shard, request, WriteOp::Put).await?;
+        let routing_key = self
+            .partition_key
+            .as_deref()
+            .unwrap_or(&self.key)
+            .to_string();
+        let PutBuilder {
+            key,
+            value,
+            expected_version_id,
+            partition_key,
+            sequence_key_deltas,
+            secondary_indexes,
+            ephemeral,
+            ..
+        } = self;
+        let identity = client.identity().to_string();
+        // Re-resolve the shard and (for ephemeral puts) its session on each
+        // attempt, so a split/merge re-routes to the new shard.
+        let response = client
+            .with_shard_retry(&routing_key, |shard| {
+                let client = client.clone();
+                let key = key.clone();
+                let value = value.clone();
+                let partition_key = partition_key.clone();
+                let sequence_key_deltas = sequence_key_deltas.clone();
+                let secondary_indexes = secondary_indexes.clone();
+                let identity = identity.clone();
+                async move {
+                    let session_id = if ephemeral {
+                        Some(client.session_id_for(shard).await?)
+                    } else {
+                        None
+                    };
+                    let request = proto::PutRequest {
+                        key,
+                        value,
+                        expected_version_id,
+                        session_id,
+                        client_identity: Some(identity),
+                        partition_key,
+                        sequence_key_delta: sequence_key_deltas,
+                        secondary_indexes,
+                        override_version_id: None,
+                        override_modifications_count: None,
+                    };
+                    client.submit_write(shard, request, WriteOp::Put).await
+                }
+            })
+            .await?;
         check_status(response.status)?;
         let version = response
             .version
@@ -126,7 +155,7 @@ impl PutBuilder {
         Ok(PutResult {
             // The server returns the key only when it generated it
             // (sequential keys).
-            key: response.key.unwrap_or(self.key),
+            key: response.key.unwrap_or(key),
             version: version.into(),
         })
     }
@@ -204,8 +233,13 @@ impl GetBuilder {
         };
         match self.partition_key {
             Some(partition_key) => {
-                let shard = client.shard_for(&partition_key)?;
-                let response = client.submit_get(shard, request).await?;
+                let response = client
+                    .with_shard_retry(&partition_key, |shard| {
+                        let client = client.clone();
+                        let request = request.clone();
+                        async move { client.submit_get(shard, request).await }
+                    })
+                    .await?;
                 check_status(response.status)?;
                 GetResult::from_proto(response, Some(self.key))
             }
@@ -262,13 +296,22 @@ impl DeleteBuilder {
     async fn execute(self) -> Result<(), OxiaError> {
         let client = self.client;
         client.ensure_open()?;
-        let routing_key = self.partition_key.as_deref().unwrap_or(&self.key);
-        let shard = client.shard_for(routing_key)?;
+        let routing_key = self
+            .partition_key
+            .as_deref()
+            .unwrap_or(&self.key)
+            .to_string();
         let request = proto::DeleteRequest {
             key: self.key,
             expected_version_id: self.expected_version_id,
         };
-        let response = client.submit_write(shard, request, WriteOp::Delete).await?;
+        let response = client
+            .with_shard_retry(&routing_key, |shard| {
+                let client = client.clone();
+                let request = request.clone();
+                async move { client.submit_write(shard, request, WriteOp::Delete).await }
+            })
+            .await?;
         check_status(response.status)
     }
 }
@@ -323,9 +366,16 @@ impl DeleteRangeBuilder {
         };
         match self.partition_key {
             Some(partition_key) => {
-                let shard = client.shard_for(&partition_key)?;
                 let response = client
-                    .submit_write(shard, request, WriteOp::DeleteRange)
+                    .with_shard_retry(&partition_key, |shard| {
+                        let client = client.clone();
+                        let request = request.clone();
+                        async move {
+                            client
+                                .submit_write(shard, request, WriteOp::DeleteRange)
+                                .await
+                        }
+                    })
                     .await?;
                 check_status(response.status)
             }

--- a/oxia-client/src/retry.rs
+++ b/oxia-client/src/retry.rs
@@ -32,6 +32,36 @@ pub(crate) fn retry_delay(attempt: u32) -> Duration {
         .min(OP_RETRY_MAX_DELAY)
 }
 
+/// Repeatedly runs `attempt` until it returns a value or an error for which
+/// `is_retryable` is false, or `timeout` elapses (returning the last retryable
+/// error). Backs off between attempts. This drives the client's operation-level
+/// re-routing/retries (shard split/merge, assignments not yet loaded).
+pub(crate) async fn retry_until<T, A, Fut>(
+    timeout: Duration,
+    is_retryable: impl Fn(&OxiaError) -> bool,
+    mut attempt: A,
+) -> Result<T, OxiaError>
+where
+    A: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, OxiaError>>,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut n = 0u32;
+    loop {
+        match attempt().await {
+            Err(err) if is_retryable(&err) => {
+                let delay = retry_delay(n);
+                n += 1;
+                if tokio::time::Instant::now() + delay >= deadline {
+                    return Err(err);
+                }
+                tokio::time::sleep(delay).await;
+            }
+            other => return other,
+        }
+    }
+}
+
 /// The failure mode of a single attempt of a retried operation.
 pub(crate) enum RetryError {
     /// A transient failure; retry after a backoff delay.
@@ -141,6 +171,75 @@ mod tests {
             Err(RetryError::transient(OxiaError::Timeout))
         })
         .await;
+    }
+
+    #[tokio::test]
+    async fn retry_until_returns_ok_without_retrying() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let calls = AtomicU32::new(0);
+        let out: Result<u32, OxiaError> = retry_until(
+            Duration::from_secs(60),
+            |_| true,
+            || async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(7)
+            },
+        )
+        .await;
+        assert_eq!(out.unwrap(), 7);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn retry_until_returns_non_retryable_immediately() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let calls = AtomicU32::new(0);
+        let out: Result<(), OxiaError> = retry_until(
+            Duration::from_secs(60),
+            |e| e.is_retryable(),
+            || async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Err(OxiaError::KeyNotFound)
+            },
+        )
+        .await;
+        assert!(matches!(out, Err(OxiaError::KeyNotFound)));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_until_retries_then_succeeds() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        // Fail with a retryable error twice (e.g. shard still moving), then
+        // succeed once the new assignment lands. Paused time makes the backoff
+        // sleeps instant.
+        let calls = AtomicU32::new(0);
+        let out: Result<u32, OxiaError> = retry_until(
+            Duration::from_secs(60),
+            |e| e.is_retryable(),
+            || async {
+                let n = calls.fetch_add(1, Ordering::SeqCst);
+                if n < 2 {
+                    Err(OxiaError::ShardMoved)
+                } else {
+                    Ok(n)
+                }
+            },
+        )
+        .await;
+        assert_eq!(out.unwrap(), 2);
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_until_gives_up_at_deadline_with_last_error() {
+        let out: Result<(), OxiaError> = retry_until(
+            Duration::from_secs(1),
+            |e| e.is_retryable(),
+            || async { Err(OxiaError::ShardMoved) },
+        )
+        .await;
+        assert!(matches!(out, Err(OxiaError::ShardMoved)));
     }
 
     #[tokio::test]

--- a/oxia-client/src/server_error.rs
+++ b/oxia-client/src/server_error.rs
@@ -14,6 +14,7 @@ const OXIA_ERROR_DOMAIN: &str = "oxia.io";
 const METADATA_SHARD: &str = "shard";
 const METADATA_LEADER: &str = "leader";
 const REASON_SESSION_NOT_FOUND: &str = "SESSION_NOT_FOUND";
+const REASON_SHARD_NOT_FOUND: &str = "SHARD_NOT_FOUND";
 
 /// The address of a shard's current leader, extracted from an error's details.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -75,6 +76,8 @@ pub(crate) fn decode_status(status: Status) -> DecodedStatus {
 
     let error = match info.reason.as_str() {
         REASON_SESSION_NOT_FOUND => OxiaError::SessionExpired,
+        // A split/merged shard: the operation re-routes to the new shard.
+        REASON_SHARD_NOT_FOUND => OxiaError::ShardMoved,
         _ => OxiaError::from(status),
     };
 
@@ -129,6 +132,14 @@ mod tests {
         assert_eq!(hint.leader, "server-2:6648");
         assert_eq!(hint.address_for(7), Some("server-2:6648"));
         assert_eq!(hint.address_for(8), None);
+    }
+
+    #[test]
+    fn shard_not_found_reason_maps_to_shard_moved() {
+        let status = oxia_status(Code::NotFound, "SHARD_NOT_FOUND", HashMap::new());
+        let decoded = decode_status(status);
+        assert!(matches!(decoded.error, OxiaError::ShardMoved));
+        assert!(decoded.error.is_retryable());
     }
 
     #[test]

--- a/oxia-client/src/shard_manager.rs
+++ b/oxia-client/src/shard_manager.rs
@@ -279,6 +279,16 @@ impl ShardManager {
     }
 
     /// The ids of all shards in the namespace, per the current assignments.
+    /// Whether the shard is present in the current assignments (false once it
+    /// has been split or merged away).
+    pub fn shard_exists(&self, shard_id: i64) -> bool {
+        self.inner
+            .assignments
+            .load()
+            .leaders
+            .contains_key(&shard_id)
+    }
+
     pub fn get_shard_ids(&self) -> Vec<i64> {
         self.inner
             .assignments


### PR DESCRIPTION
Completes Phase 1's failure-handling core: when a shard splits or merges, operations still targeting the retired shard id now land on the new shard instead of failing. Builds directly on the retry machinery from #38.

## Mechanism

The server answers an operation for a retired shard with `NotFound` + `ErrorInfo` reason `SHARD_NOT_FOUND`.

- **Decode** → a new retryable `OxiaError::ShardMoved`. A batcher that can no longer resolve its shard's leader tells a transient election (`LeaderNotFound`, retried in place) apart from a shard that is *gone* (`ShardMoved`) via `ShardManager::shard_exists` against the current assignment snapshot.
- **Batchers don't retry `ShardMoved`** against the dead shard — write and read batches fail their ops with it so the caller re-routes.
- **Builders re-route** — `with_shard_retry` re-resolves the owning shard and retries put / get / delete / single-shard delete-range while routing is unavailable: `ShardMoved` (just split/merged) **or** `NoShardForKey` (assignments not loaded yet). That second case closes a real gap — an operation racing a reassignment previously failed outright. Broadcast get and delete-range re-issue against the current shard set via `with_reroute_retry` (idempotent). All bounded by the request timeout with exponential backoff.

Re-routing keys match Go exactly — put by partition-key-or-key, delete/get by key, delete-range broadcast — and all are on the wire request, so **no per-operation routing state is threaded** through the batchers.

## Testing

The retry loop is extracted as `retry::retry_until` and unit-tested with **paused tokio time**: succeeds after transient failures, returns non-retryable errors immediately, gives up at the deadline with the last error.

An honest note on the end-to-end test: triggering a real split needs the coordinator's `SplitShard` admin RPC, which `oxia standalone` doesn't expose — and the reference Go/Java clients likewise **unit-test** reroute rather than driving live splits. A true split test belongs to the multi-node failure suite (**P1-G**).

## Verification
fmt / clippy `-D warnings` / `cargo doc` clean · **44 unit** (5 new: decode `ShardMoved`, classification, 4 `retry_until` control-flow cases) · **12 doc** · **50 integration** · **2 interop** — all green under `--test-threads=4`.

(Branch note: recreated cleanly atop current main via cherry-pick after #38 merged, so it's a single commit.)