### PR TITLE
feat: make notifications() live on return; stop subscription managers on drop

### DIFF
--- a/oxia-client/src/client.rs
+++ b/oxia-client/src/client.rs
@@ -26,10 +26,10 @@ use dashmap::DashMap;
 use futures::StreamExt;
 use futures::future::try_join_all;
 use std::fmt;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Weak};
 use std::time::Duration;
-use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinSet;
 use tracing::warn;
 
@@ -39,11 +39,43 @@ pub(crate) struct Inner {
     pub(crate) shard_manager: Arc<ShardManager>,
     pub(crate) session_manager: Arc<SessionManager>,
     batcher_deps: Arc<BatcherDeps>,
-    notification_tasks: Mutex<Vec<NotificationManager>>,
-    sequence_tasks: Mutex<Vec<SequenceUpdatesManager>>,
+    notification_managers: DashMap<u64, NotificationManager>,
+    sequence_managers: DashMap<u64, SequenceUpdatesManager>,
+    next_subscription_id: AtomicU64,
     write_batchers: DashMap<i64, Arc<WriteBatcher>>,
     read_batchers: DashMap<i64, Arc<ReadBatcher>>,
     closed: AtomicBool,
+}
+
+/// Which registry a [`SubscriptionGuard`] cleans up.
+enum SubscriptionKind {
+    Notification,
+    Sequence,
+}
+
+/// Held by a [`Notifications`]/[`SequenceUpdates`] handle; on drop it removes
+/// the backing manager from the client, stopping its listener task(s). A [`Weak`]
+/// reference means a dropped handle after the client is gone is a no-op.
+pub(crate) struct SubscriptionGuard {
+    inner: Weak<Inner>,
+    id: u64,
+    kind: SubscriptionKind,
+}
+
+impl Drop for SubscriptionGuard {
+    fn drop(&mut self) {
+        let Some(inner) = self.inner.upgrade() else {
+            return;
+        };
+        match self.kind {
+            SubscriptionKind::Notification => {
+                inner.notification_managers.remove(&self.id);
+            }
+            SubscriptionKind::Sequence => {
+                inner.sequence_managers.remove(&self.id);
+            }
+        }
+    }
 }
 
 /// The Oxia client.
@@ -146,8 +178,9 @@ impl OxiaClient {
                 shard_manager,
                 session_manager,
                 batcher_deps,
-                notification_tasks: Mutex::new(Vec::new()),
-                sequence_tasks: Mutex::new(Vec::new()),
+                notification_managers: DashMap::new(),
+                sequence_managers: DashMap::new(),
+                next_subscription_id: AtomicU64::new(0),
                 write_batchers: DashMap::new(),
                 read_batchers: DashMap::new(),
                 closed: AtomicBool::new(false),
@@ -486,11 +519,27 @@ impl OxiaClient {
                 track(&mut first_err, batcher.close().await, "read batcher");
             }
         }
-        for manager in self.inner.notification_tasks.lock().await.drain(..) {
-            track(&mut first_err, manager.shutdown().await, "notifications");
+        let notification_ids: Vec<u64> = self
+            .inner
+            .notification_managers
+            .iter()
+            .map(|e| *e.key())
+            .collect();
+        for id in notification_ids {
+            if let Some((_, manager)) = self.inner.notification_managers.remove(&id) {
+                track(&mut first_err, manager.shutdown().await, "notifications");
+            }
         }
-        for manager in self.inner.sequence_tasks.lock().await.drain(..) {
-            track(&mut first_err, manager.shutdown().await, "sequence updates");
+        let sequence_ids: Vec<u64> = self
+            .inner
+            .sequence_managers
+            .iter()
+            .map(|e| *e.key())
+            .collect();
+        for id in sequence_ids {
+            if let Some((_, manager)) = self.inner.sequence_managers.remove(&id) {
+                track(&mut first_err, manager.shutdown().await, "sequence updates");
+            }
         }
         track(
             &mut first_err,
@@ -857,14 +906,36 @@ impl OxiaClient {
         buffer_size: usize,
     ) -> Result<Notifications, OxiaError> {
         self.ensure_open()?;
+        let shards = self.inner.shard_manager.get_shard_ids();
+        let shard_count = shards.len();
         let (tx, rx) = mpsc::channel(buffer_size);
+        let (init_tx, mut init_rx) = mpsc::channel(shard_count.max(1));
         let manager = NotificationManager::new(
+            shards,
             self.inner.shard_manager.clone(),
             self.inner.provider_manager.clone(),
             tx,
+            init_tx,
         );
-        self.inner.notification_tasks.lock().await.push(manager);
-        Ok(Notifications::new(rx))
+        // Make the subscription live before returning, so no change in the
+        // window between here and the first stream is missed. Returning early
+        // (on error/timeout) drops `manager`, cancelling every listener.
+        let deadline = tokio::time::Instant::now() + self.request_timeout();
+        let mut ready = 0;
+        while ready < shard_count {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            match tokio::time::timeout(remaining, init_rx.recv()).await {
+                Ok(Some(Ok(()))) => ready += 1,
+                Ok(Some(Err(err))) => return Err(err),
+                Ok(None) => break,
+                Err(_) => return Err(OxiaError::Timeout),
+            }
+        }
+        let id = self.register_notification_manager(manager);
+        Ok(Notifications::new(
+            rx,
+            self.subscription_guard(id, SubscriptionKind::Notification),
+        ))
     }
 
     pub(crate) async fn open_sequence_updates(
@@ -882,8 +953,36 @@ impl OxiaClient {
             self.inner.provider_manager.clone(),
             tx,
         );
-        self.inner.sequence_tasks.lock().await.push(manager);
-        Ok(SequenceUpdates::new(rx))
+        let id = self
+            .inner
+            .next_subscription_id
+            .fetch_add(1, Ordering::Relaxed);
+        self.inner.sequence_managers.insert(id, manager);
+        Ok(SequenceUpdates::new(
+            rx,
+            self.subscription_guard(id, SubscriptionKind::Sequence),
+        ))
+    }
+
+    /// Registers a live notification manager so [`close`](Self::close) can shut
+    /// it down, returning the id used to remove it when its handle is dropped.
+    fn register_notification_manager(&self, manager: NotificationManager) -> u64 {
+        let id = self
+            .inner
+            .next_subscription_id
+            .fetch_add(1, Ordering::Relaxed);
+        self.inner.notification_managers.insert(id, manager);
+        id
+    }
+
+    /// Builds the guard a subscription handle holds; dropping the handle removes
+    /// (and thereby stops) the registered manager.
+    fn subscription_guard(&self, id: u64, kind: SubscriptionKind) -> SubscriptionGuard {
+        SubscriptionGuard {
+            inner: Arc::downgrade(&self.inner),
+            id,
+            kind,
+        }
     }
 
     /// Broadcasts a delete-range to every shard, re-issuing against the current

--- a/oxia-client/src/notification_manager.rs
+++ b/oxia-client/src/notification_manager.rs
@@ -1,60 +1,78 @@
+//! Per-shard notification subscriptions for one [`Notifications`] handle.
+//!
+//! One listener task per shard streams that shard's change notifications into a
+//! shared channel, reconnecting (resuming from the last delivered offset) after
+//! connection loss. All listeners share one [`CancellationToken`], so dropping
+//! the manager — which happens when the [`Notifications`] handle is dropped or
+//! the client is closed — stops every listener promptly.
+//!
+//! Notifications from one shard are delivered in the order the server applied
+//! them (the batch is a server-sorted `repeated NotificationEntry`); ordering
+//! across shards is unspecified.
+//!
+//! [`Notifications`]: crate::Notifications
+
 use crate::errors::OxiaError;
 use crate::proto::NotificationsRequest;
 use crate::provider_manager::ProviderManager;
 use crate::retry::{RetryError, retry_until_cancelled};
 use crate::shard_manager::ShardManager;
 use crate::types::Notification;
-use dashmap::DashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicI64, Ordering};
-use task::JoinHandle;
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use tokio::sync::Mutex;
 use tokio::sync::mpsc::Sender;
-use tokio::task;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tonic::codegen::tokio_stream::StreamExt;
-use tracing::{info, warn};
+use tracing::{debug, warn};
 
-struct NotificationListener {
+pub(crate) struct NotificationManager {
     context: CancellationToken,
-    join_handle: Mutex<Option<JoinHandle<()>>>,
+    handles: Mutex<Vec<JoinHandle<()>>>,
 }
 
-impl Drop for NotificationListener {
+impl Drop for NotificationManager {
     fn drop(&mut self) {
         self.context.cancel();
     }
 }
 
-impl NotificationListener {
-    pub fn new(
-        shard_id: i64,
+impl NotificationManager {
+    /// Spawns a listener per shard. Each reports once, via `init_tx`, whether it
+    /// established its first subscription (`Ok`) or hit a permanent error
+    /// (`Err`); the caller waits on these to make the subscription live before
+    /// returning to the user.
+    pub(crate) fn new(
+        shards: Vec<i64>,
         shard_manager: Arc<ShardManager>,
         provider_manager: Arc<ProviderManager>,
         sender: Sender<Notification>,
+        init_tx: tokio::sync::mpsc::Sender<Result<(), OxiaError>>,
     ) -> Self {
         let context = CancellationToken::new();
-        let start_offset = Arc::new(AtomicI64::new(-1));
-
-        let passing_context = context.clone();
-        let passing_start_offset = start_offset.clone();
-        let handle = tokio::spawn(start_notification_listener(
-            shard_id,
-            shard_manager,
-            provider_manager,
-            sender,
-            passing_context,
-            passing_start_offset,
-        ));
-        NotificationListener {
+        let handles = shards
+            .into_iter()
+            .map(|shard_id| {
+                tokio::spawn(start_notification_listener(
+                    shard_id,
+                    shard_manager.clone(),
+                    provider_manager.clone(),
+                    sender.clone(),
+                    context.clone(),
+                    init_tx.clone(),
+                ))
+            })
+            .collect();
+        NotificationManager {
             context,
-            join_handle: Mutex::new(Some(handle)),
+            handles: Mutex::new(handles),
         }
     }
-    pub async fn shutdown(self) -> Result<(), OxiaError> {
+
+    pub(crate) async fn shutdown(self) -> Result<(), OxiaError> {
         self.context.cancel();
-        let mut handle_guard = self.join_handle.lock().await;
-        if let Some(handle) = handle_guard.take() {
+        for handle in self.handles.lock().await.drain(..) {
             handle
                 .await
                 .map_err(|err| OxiaError::Disconnected(err.to_string()))?;
@@ -68,15 +86,28 @@ async fn start_notification_listener(
     shard_manager: Arc<ShardManager>,
     provider_manager: Arc<ProviderManager>,
     sender: Sender<Notification>,
-    passing_context: CancellationToken,
-    passing_start_offset: Arc<AtomicI64>,
+    context: CancellationToken,
+    init_tx: tokio::sync::mpsc::Sender<Result<(), OxiaError>>,
 ) {
+    // The last offset delivered by the server, tracked across reconnects. A
+    // negative value means "not yet positioned": the first request omits the
+    // offset (`None`), which the server answers with an initial empty batch
+    // that primes the notification cursor. Reconnects resume from the last
+    // offset so nothing in the gap is missed.
+    let last_offset = Arc::new(AtomicI64::new(-1));
+    // Readiness is reported exactly once per listener; a reconnect must not
+    // signal it again, or the init wait could over-count and return before a
+    // slower shard is live.
+    let reported = Arc::new(AtomicBool::new(false));
+
     let defer = || {
-        let context = passing_context.clone();
-        let offset_ref = passing_start_offset.clone();
+        let context = context.clone();
+        let offset_ref = last_offset.clone();
+        let reported = reported.clone();
         let shard_manager = shard_manager.clone();
         let provider_manager = provider_manager.clone();
         let sender = sender.clone();
+        let init_tx = init_tx.clone();
         async move {
             let mut provider = match shard_manager.get_leader(shard_id) {
                 None => {
@@ -89,80 +120,66 @@ async fn start_notification_listener(
                     .await
                     .map_err(RetryError::transient)?,
             };
-            let mut streaming = provider
+            let offset = offset_ref.load(Ordering::Acquire);
+            let mut streaming = match provider
                 .get_notifications(NotificationsRequest {
                     shard: shard_id,
-                    start_offset_exclusive: Some(offset_ref.load(Ordering::Acquire)),
+                    start_offset_exclusive: (offset >= 0).then_some(offset),
                 })
                 .await
-                .map_err(|err| RetryError::transient(OxiaError::from(err)))?
-                .into_inner();
+            {
+                Ok(response) => response.into_inner(),
+                Err(status) => {
+                    let err = OxiaError::from(status);
+                    // A permanent failure (e.g. notifications disabled server-
+                    // side) is reported to the caller so the subscription call
+                    // fails fast instead of retrying forever.
+                    if err.is_retryable() {
+                        return Err(RetryError::transient(err));
+                    }
+                    if !reported.swap(true, Ordering::AcqRel) {
+                        let _ = init_tx.send(Err(err.clone())).await;
+                    }
+                    return Err(RetryError::fatal(err));
+                }
+            };
             loop {
                 tokio::select! {
-                     _ = context.cancelled() => {
-                    info!("Close notification listener due to context canceled. shard_id={:?}", shard_id);
-                    break;
-                },
-                message = streaming.next() => match message {
+                    _ = context.cancelled() => {
+                        debug!(shard = shard_id, "notification listener stopped: cancelled");
+                        return Ok(());
+                    }
+                    message = streaming.next() => match message {
                         None => {
                             return Err(RetryError::transient(OxiaError::Disconnected(
                                 "notification stream closed by server".to_string(),
-                            ))); }
+                            )));
+                        }
                         Some(notification) => {
-                            let batch = notification.map_err(|err| {
-                                RetryError::transient(OxiaError::from(err))
-                            })?;
+                            let batch = notification
+                                .map_err(|err| RetryError::transient(OxiaError::from(err)))?;
                             offset_ref.store(batch.offset, Ordering::Release);
-                            for entry in batch.notifications {
-                                    let Some(notification) = Notification::from_proto(entry) else {
-                                        warn!("skipping unrecognized notification type");
-                                        continue;
-                                    };
-                                    if sender.send(notification).await.is_err() {
-                                        // Receiver dropped, stop listening
-                                        return Ok(());
-                                    }
+                            // The first batch received confirms the subscription
+                            // is live: it is the server's empty cursor-priming
+                            // batch, so the loop below emits nothing for it.
+                            if !reported.swap(true, Ordering::AcqRel) {
+                                let _ = init_tx.send(Ok(())).await;
                             }
+                            for entry in batch.notifications {
+                                let Some(notification) = Notification::from_proto(entry) else {
+                                    warn!("skipping unrecognized notification type");
+                                    continue;
+                                };
+                                if sender.send(notification).await.is_err() {
+                                    // The Notifications handle was dropped.
+                                    return Ok(());
+                                }
+                            }
+                        }
                     }
                 }
-                }
             }
-            Ok(())
         }
     };
-    retry_until_cancelled(&passing_context, "notifications", defer).await;
-}
-
-pub struct NotificationManager {
-    listener: DashMap<i64, NotificationListener>,
-}
-
-impl NotificationManager {
-    pub fn new(
-        shard_manager: Arc<ShardManager>,
-        provider_manager: Arc<ProviderManager>,
-        sender: Sender<Notification>,
-    ) -> Self {
-        let manager = Self {
-            listener: DashMap::new(),
-        };
-        for shard_id in shard_manager.get_shard_ids() {
-            let shard_sender = sender.clone();
-            let listener = NotificationListener::new(
-                shard_id,
-                shard_manager.clone(),
-                provider_manager.clone(),
-                shard_sender,
-            );
-            manager.listener.insert(shard_id, listener);
-        }
-        manager
-    }
-
-    pub async fn shutdown(self) -> Result<(), OxiaError> {
-        for (_, listener) in self.listener.into_iter() {
-            listener.shutdown().await?
-        }
-        Ok(())
-    }
+    retry_until_cancelled(&context, "notifications", defer).await;
 }

--- a/oxia-client/src/sequence_updates_manager.rs
+++ b/oxia-client/src/sequence_updates_manager.rs
@@ -17,6 +17,12 @@ pub struct SequenceUpdatesManager {
     handle: Mutex<Option<JoinHandle<()>>>,
 }
 
+impl Drop for SequenceUpdatesManager {
+    fn drop(&mut self) {
+        self.context.cancel();
+    }
+}
+
 impl SequenceUpdatesManager {
     pub fn new(
         key: String,

--- a/oxia-client/src/streams.rs
+++ b/oxia-client/src/streams.rs
@@ -1,6 +1,7 @@
 //! Streaming result types: ordered range scans / lists merged across shards,
 //! and the notification / sequence-update subscription handles.
 
+use crate::client::SubscriptionGuard;
 use crate::errors::OxiaError;
 use crate::key;
 use crate::types::{GetResult, Notification};
@@ -180,14 +181,15 @@ impl fmt::Debug for RangeScanStream {
 /// survives connection loss: each per-shard listener reconnects and resumes
 /// from its last delivered offset. Dropping the handle releases the
 /// subscription.
-#[derive(Debug)]
 pub struct Notifications {
     rx: mpsc::Receiver<Notification>,
+    // Stops the per-shard listeners when this handle is dropped.
+    _guard: SubscriptionGuard,
 }
 
 impl Notifications {
-    pub(crate) fn new(rx: mpsc::Receiver<Notification>) -> Self {
-        Notifications { rx }
+    pub(crate) fn new(rx: mpsc::Receiver<Notification>, guard: SubscriptionGuard) -> Self {
+        Notifications { rx, _guard: guard }
     }
 
     /// Receives the next notification.
@@ -196,6 +198,12 @@ impl Notifications {
     /// returned future loses no notification.
     pub async fn recv(&mut self) -> Option<Notification> {
         self.rx.recv().await
+    }
+}
+
+impl fmt::Debug for Notifications {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Notifications").finish_non_exhaustive()
     }
 }
 
@@ -215,14 +223,15 @@ impl Stream for Notifications {
 /// key. The subscription survives connection loss and re-subscribes
 /// automatically. Consume it with [`recv`](SequenceUpdates::recv) or as a
 /// [`Stream`]; dropping the handle releases the subscription.
-#[derive(Debug)]
 pub struct SequenceUpdates {
     rx: mpsc::Receiver<String>,
+    // Stops the listener when this handle is dropped.
+    _guard: SubscriptionGuard,
 }
 
 impl SequenceUpdates {
-    pub(crate) fn new(rx: mpsc::Receiver<String>) -> Self {
-        SequenceUpdates { rx }
+    pub(crate) fn new(rx: mpsc::Receiver<String>, guard: SubscriptionGuard) -> Self {
+        SequenceUpdates { rx, _guard: guard }
     }
 
     /// Receives the next sequence key.
@@ -231,6 +240,12 @@ impl SequenceUpdates {
     /// returned future loses no update.
     pub async fn recv(&mut self) -> Option<String> {
         self.rx.recv().await
+    }
+}
+
+impl fmt::Debug for SequenceUpdates {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SequenceUpdates").finish_non_exhaustive()
     }
 }
 

--- a/oxia-client/tests/integration_tests.rs
+++ b/oxia-client/tests/integration_tests.rs
@@ -515,10 +515,9 @@ async fn test_notifications() {
     let (_container, address) = start_oxia().await;
     let client = new_client(&address).await;
 
+    // No warm-up sleep: `notifications()` only returns once every shard's
+    // subscription is live, so the changes below cannot race ahead of it.
     let mut notification_rx = client.notifications().await.unwrap();
-
-    // Give notification listener time to connect
-    tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Create a key
     client
@@ -577,6 +576,61 @@ async fn test_notifications() {
     ));
 
     client.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_notifications_live_on_return() {
+    // The subscription must be live the instant `notifications()` returns: a
+    // change made immediately afterwards, with no delay, is still delivered.
+    let (_container, address) = start_oxia().await;
+    let client = new_client(&address).await;
+
+    let mut rx = client.notifications().await.unwrap();
+    client
+        .put("live/key".to_string(), b"v".to_vec())
+        .await
+        .unwrap();
+
+    let got = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("notification not delivered in time")
+        .expect("notification stream closed");
+    assert!(matches!(
+        got,
+        Notification::KeyCreated { key, .. } if key == "live/key"
+    ));
+
+    client.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_notifications_drop_releases_subscription() {
+    // Dropping the handle stops its listeners and leaves the client healthy:
+    // a fresh subscription still works and shutdown completes promptly.
+    let (_container, address) = start_oxia().await;
+    let client = new_client(&address).await;
+
+    let rx = client.notifications().await.unwrap();
+    drop(rx);
+
+    let mut rx2 = client.notifications().await.unwrap();
+    client
+        .put("drop/key".to_string(), b"v".to_vec())
+        .await
+        .unwrap();
+    let got = tokio::time::timeout(Duration::from_secs(5), rx2.recv())
+        .await
+        .expect("notification not delivered in time")
+        .expect("notification stream closed");
+    assert!(matches!(
+        got,
+        Notification::KeyCreated { key, .. } if key == "drop/key"
+    ));
+
+    tokio::time::timeout(Duration::from_secs(5), client.close())
+        .await
+        .expect("close hung after dropping a subscription")
+        .unwrap();
 }
 
 // ============================================================


### PR DESCRIPTION
## What

Two related fixes to the notifications / sequence-updates subscription lifecycle (roadmap **P1-13** and **P1-14**).

### P1-13 — `notifications()` blocks until subscriptions are live

`notifications()` now waits for **every shard's** per-shard listener to establish its subscription before returning, so a change made immediately afterward cannot race ahead of the subscription. The wait is bounded by the request timeout (returns `OxiaError::Timeout`) and fails fast on a permanent error (e.g. notifications disabled server-side).

The mechanism mirrors the Go client: the **first** request per shard omits `start_offset_exclusive`, which makes the server send an empty *cursor-priming* batch. Receiving that batch confirms the subscription is live **and** positions it at the tail; reconnects then resume from the last delivered offset.

This also fixes a latent bug: the client previously always sent `start_offset_exclusive = -1`. Per the server's `GetNotifications` handler, that suppresses the priming batch entirely — so "live" was never observable — and it replays **all** history rather than tailing. (The old code only worked because it never waited; the stream would establish lazily when the first unrelated change occurred.)

### P1-14 — ordered delivery + teardown on handle drop

- Per-shard notifications are delivered in the server's applied order (each batch is a server-sorted `repeated NotificationEntry`); cross-shard interleaving is unspecified. This is now documented on the module and the public `Notifications` type.
- `NotificationManager` / `SequenceUpdatesManager` are held in **keyed registries** and torn down when their handle is dropped — not only on `close()`. Dropping a `Notifications` / `SequenceUpdates` handle removes its manager (via a `SubscriptionGuard` holding a `Weak<Inner>`) and cancels the listener task(s). `SequenceUpdatesManager` gained a `Drop` that cancels its context so registry removal actually stops the listener.

## Tests

- `test_notifications_live_on_return` — a put issued with **no** warm-up delay after `notifications()` is still delivered (regression test for the init-wait).
- `test_notifications_drop_releases_subscription` — dropping a handle leaves the client healthy; a fresh subscription still works and `close()` completes promptly.
- Removed the now-unnecessary 500 ms warm-up sleep from `test_notifications`, turning it into a real init-wait regression test.

All suites green locally: unit (44), doc (12), integration (52), interop (2); `fmt` + `clippy --all-targets -D warnings` clean.