### PR TITLE
feat: route exact-match gets to the owning shard instead of broadcasting

### DIFF
--- a/oxia-client/src/client.rs
+++ b/oxia-client/src/client.rs
@@ -243,6 +243,10 @@ impl OxiaClient {
     /// one. Records written with a partition key must be read with the same
     /// partition key.
     ///
+    /// An exact-match get is routed to the single shard that owns the key (or
+    /// the partition key, when given); an inequality comparison or a
+    /// secondary-index lookup instead fans out across all shards.
+    ///
     /// # Errors
     ///
     /// Awaiting the builder returns:
@@ -697,8 +701,10 @@ impl OxiaClient {
     }
 
     /// Runs a get against every shard and reduces the per-shard winners
-    /// according to the comparison type (used when no partition key pins the
-    /// query to one shard).
+    /// according to the comparison type. Used only when the query is not pinned
+    /// to a single shard — i.e. an inequality comparison or a secondary-index
+    /// lookup with no partition key; an exact-match primary-key get is routed
+    /// directly to its owning shard instead.
     pub(crate) async fn broadcast_get(
         &self,
         request: proto::GetRequest,

--- a/oxia-client/src/requests.rs
+++ b/oxia-client/src/requests.rs
@@ -225,25 +225,30 @@ impl GetBuilder {
     async fn execute(self) -> Result<GetResult, OxiaError> {
         let client = self.client;
         client.ensure_open()?;
+        let single_shard = is_single_shard_get(
+            self.partition_key.is_some(),
+            self.comparison,
+            self.secondary_index_name.is_some(),
+        );
         let request = proto::GetRequest {
             key: self.key.clone(),
             include_value: self.include_value,
             comparison_type: self.comparison.to_proto() as i32,
             secondary_index_name: self.secondary_index_name,
         };
-        match self.partition_key {
-            Some(partition_key) => {
-                let response = client
-                    .with_shard_retry(&partition_key, |shard| {
-                        let client = client.clone();
-                        let request = request.clone();
-                        async move { client.submit_get(shard, request).await }
-                    })
-                    .await?;
-                check_status(response.status)?;
-                GetResult::from_proto(response, Some(self.key))
-            }
-            None => client.broadcast_get(request, self.comparison).await,
+        if single_shard {
+            let route_key = self.partition_key.unwrap_or_else(|| self.key.clone());
+            let response = client
+                .with_shard_retry(&route_key, |shard| {
+                    let client = client.clone();
+                    let request = request.clone();
+                    async move { client.submit_get(shard, request).await }
+                })
+                .await?;
+            check_status(response.status)?;
+            GetResult::from_proto(response, Some(self.key))
+        } else {
+            client.broadcast_get(request, self.comparison).await
         }
     }
 }
@@ -255,6 +260,21 @@ impl IntoFuture for GetBuilder {
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.execute())
     }
+}
+
+/// Whether a get is pinned to a single shard (routed by partition key, or by
+/// the primary key for an exact match) rather than broadcast to every shard.
+///
+/// A partition key always pins the query. Without one, only an exact
+/// ([`Equal`](ComparisonType::Equal)) primary-key lookup owns a single shard;
+/// an inequality comparison (its nearest match may sit on any shard) or a
+/// secondary-index lookup (indexed independently on each shard) must fan out.
+fn is_single_shard_get(
+    has_partition_key: bool,
+    comparison: ComparisonType,
+    has_secondary_index: bool,
+) -> bool {
+    has_partition_key || (comparison == ComparisonType::Equal && !has_secondary_index)
 }
 
 /// A pending `delete`, created with [`OxiaClient::delete`]. Chain options and
@@ -642,5 +662,49 @@ impl IntoFuture for SequenceUpdatesBuilder {
                 .open_sequence_updates(self.key, self.partition_key, self.buffer_size)
                 .await
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn equal_primary_key_get_is_single_shard() {
+        // The common case: exact get by key, no partition key, no index.
+        assert!(is_single_shard_get(false, ComparisonType::Equal, false));
+    }
+
+    #[test]
+    fn a_partition_key_always_pins_the_shard() {
+        for comparison in [
+            ComparisonType::Equal,
+            ComparisonType::Floor,
+            ComparisonType::Ceiling,
+            ComparisonType::Lower,
+            ComparisonType::Higher,
+        ] {
+            assert!(is_single_shard_get(true, comparison, false));
+            // Even a secondary-index lookup is pinned when a partition key routes it.
+            assert!(is_single_shard_get(true, comparison, true));
+        }
+    }
+
+    #[test]
+    fn inequality_gets_without_partition_key_broadcast() {
+        for comparison in [
+            ComparisonType::Floor,
+            ComparisonType::Ceiling,
+            ComparisonType::Lower,
+            ComparisonType::Higher,
+        ] {
+            assert!(!is_single_shard_get(false, comparison, false));
+        }
+    }
+
+    #[test]
+    fn secondary_index_get_without_partition_key_broadcasts() {
+        // Even an exact match must fan out when it targets a secondary index.
+        assert!(!is_single_shard_get(false, ComparisonType::Equal, true));
     }
 }


### PR DESCRIPTION
## What (roadmap P1-15)

A `get` with the default `EQUAL` comparison and no secondary index resolves to exactly one shard by the key's hash — but the client was sending it to **every** shard and reducing the per-shard winners. That's `O(shards)` RPCs and a k-way reduction for what is a point read.

Such a get is now routed to its single owning shard, matching the Go client (`clientImpl.Get` → `doSingleShardGet` when `partitionKey != nil || (EQUAL && no secondary index)`, routed via `getShardForKey`).

### Routing, now

| partition key | comparison | secondary index | routing |
|---|---|---|---|
| set | any | any | single shard (by partition key) |
| — | `EQUAL` | — | **single shard (by key)** ← was broadcast |
| — | `EQUAL` | set | broadcast |
| — | inequality | any | broadcast |

The decision is extracted into a small pure `is_single_shard_get(...)` so it can be unit-tested directly. Broadcast queries are unchanged; the routing key is the partition key when given, else the primary key.

## Tests

- New truth-table unit tests for `is_single_shard_get` (partition key pins any comparison incl. secondary index; plain `EQUAL` is single-shard; inequality and secondary-index without a partition key broadcast).
- End-to-end correctness is covered by the existing suites: all get-by-key integration tests and the **10-shard Go↔Rust interop tests** read exact keys back across hash-distributed shards — the single-shard routing path. Floor/ceiling/lower/higher and secondary-index tests confirm broadcast still works.

All green locally: unit (48), doc (12), integration (52), interop (2); `fmt` + `clippy --all-targets -D warnings` clean.