### PR TITLE
feat: deny clippy::unwrap_used in library code

### DIFF
--- a/oxia-client/src/lib.rs
+++ b/oxia-client/src/lib.rs
@@ -82,6 +82,10 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![allow(clippy::result_large_err)]
+// A panic on wire data must never take down the caller's process: forbid
+// `.unwrap()` in library code so every fallible result is handled. Unit tests
+// (compiled with `cfg(test)`) are exempt, where unwrapping is the idiom.
+#![cfg_attr(not(test), deny(clippy::unwrap_used))]
 
 mod address;
 mod batcher;


### PR DESCRIPTION
## What (roadmap P1-16)

A panic on wire data must never take down the caller's process. The gap analysis flagged *"several `unwrap()`s on wire data"*; those were all removed over the resilience work (P1-1/P1-11 error taxonomy + read/write path reworks). This installs the guardrail so they cannot creep back:

```rust
#![cfg_attr(not(test), deny(clippy::unwrap_used))]
```

Any `.unwrap()` in non-test library code now fails the build. Unit-test modules (compiled with `cfg(test)`) stay exempt, where unwrapping is the idiom; integration tests are separate crates and unaffected.

## Scope notes

- **No production unwraps exist today** — all 11 `unwrap`/`unwrap_err` occurrences in `src/` are inside `#[cfg(test)]` modules — so the lint is clean as-is.
- The lint is `unwrap_used` only, per the task. Production `expect()`s remain: they guard mutex-poisoning and internal merge-algorithm invariants (`peeked slot filled`, `parked response stream`, `shard id → ascii metadata`) — none touch inbound wire data.

## Verification

- Confirmed the guardrail actually fires: injecting a throwaway `.unwrap()` into a production function makes `cargo clippy -p oxia-client --lib -- -D warnings` fail with `used unwrap() on ... value` pointing at the deny; removing it returns to clean. (Guards against a mis-scoped `cfg` silently disabling the lint.)
- `fmt` + `clippy --all-targets -D warnings` clean (both crates); unit (48), doc (12), integration (52), interop (2) all green.