### PR TITLE
test: add failure-mode gate suite (P1-G)

### DIFF
--- a/oxia-client/tests/integration_tests.rs
+++ b/oxia-client/tests/integration_tests.rs
@@ -1877,3 +1877,135 @@ async fn test_operations_survive_server_restart() {
     let _container = restarter.await.unwrap();
     client.close().await.unwrap();
 }
+
+// ============================================================
+// Failure-mode gate (P1-G)
+// ============================================================
+//
+// This suite exercises the client's resilience end-to-end against a real
+// server. What is covered here:
+//   - cluster-down fail-fast: `build_fails_fast_when_cluster_unreachable`
+//   - leader restart mid-operation: `test_operations_survive_server_restart`
+//   - leader restart under concurrent load: below
+//   - notification resume after reconnect: below
+//   - session expiry + ephemeral cleanup on close: `test_ephemeral_keys`
+//
+// Two gate scenarios cannot be driven against the `oxia standalone` container
+// and are covered at the unit level instead:
+//   - Shard split/merge under load: the standalone exposes only the public
+//     service (port 6648); it runs no coordinator/admin service, so the
+//     `OxiaAdmin.SplitShard` RPC is unreachable and no live split can be
+//     triggered. The re-routing logic (SHARD_NOT_FOUND -> re-hash + resubmit)
+//     is unit-tested in `client.rs`, matching how the Go/Java clients test it.
+//   - Forced session expiry: the server persists sessions and, on restart,
+//     recovers them with a fresh heartbeat timer while the client transparently
+//     resumes keep-alive — so `SESSION_NOT_FOUND` cannot be provoked through the
+//     public API without a failure-injection hook the standalone does not offer.
+//     The recreate-on-expiry path (keep-alive marks the session dead -> next
+//     ephemeral op opens a fresh session) is covered by the session-manager
+//     logic added in P1-6/P1-7.
+
+/// Receives notifications until a `KeyCreated` for `key` arrives, ignoring any
+/// others, or panics after `within`.
+async fn expect_key_created(rx: &mut oxia::Notifications, key: &str, within: Duration) {
+    let deadline = tokio::time::Instant::now() + within;
+    loop {
+        match tokio::time::timeout_at(deadline, rx.recv()).await {
+            Ok(Some(Notification::KeyCreated { key: k, .. })) if k == key => return,
+            Ok(Some(_)) => continue,
+            Ok(None) => panic!("notification stream closed before delivering '{key}'"),
+            Err(_) => panic!("timed out waiting for notification '{key}'"),
+        }
+    }
+}
+
+/// P1-G: a notification subscription must survive a server outage. Each
+/// per-shard listener reconnects and resumes from its last delivered offset, so
+/// a change made after the server returns is still delivered.
+#[tokio::test]
+async fn test_notifications_resume_after_server_restart() {
+    let (container, address) = start_oxia_fixed_port().await;
+    let client = OxiaClientBuilder::new()
+        .service_address(address)
+        .request_timeout(Duration::from_secs(60))
+        .build()
+        .await
+        .unwrap();
+
+    let mut rx = client.notifications().await.unwrap();
+
+    // A change before the outage is delivered normally.
+    client
+        .put("notif-restart/before", b"v1".to_vec())
+        .await
+        .unwrap();
+    expect_key_created(&mut rx, "notif-restart/before", Duration::from_secs(10)).await;
+
+    // Bounce the server underneath the subscription.
+    container.stop().await.expect("stop oxia");
+    let restarter = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        container.start().await.expect("restart oxia");
+        container
+    });
+
+    // A change after the server returns must still reach the subscription: the
+    // listener reconnected and resumed from where it left off.
+    client
+        .put("notif-restart/after", b"v2".to_vec())
+        .await
+        .unwrap();
+    expect_key_created(&mut rx, "notif-restart/after", Duration::from_secs(30)).await;
+
+    let _container = restarter.await.unwrap();
+    client.close().await.unwrap();
+}
+
+/// P1-G: a burst of writes already in flight when the leader restarts must all
+/// ride through the outage on the client's retries — none dropped, none stuck.
+#[tokio::test]
+async fn test_writes_survive_restart_under_concurrent_load() {
+    let (container, address) = start_oxia_fixed_port().await;
+    let client = OxiaClientBuilder::new()
+        .service_address(address)
+        .request_timeout(Duration::from_secs(60))
+        .build()
+        .await
+        .unwrap();
+
+    // Kick off a burst of concurrent writes...
+    let mut tasks = tokio::task::JoinSet::new();
+    for i in 0..50 {
+        let client = client.clone();
+        tasks.spawn(async move {
+            client
+                .put(format!("load/{i:02}"), format!("v{i}").into_bytes())
+                .await
+        });
+    }
+
+    // ...and bounce the server while they are in flight.
+    container.stop().await.expect("stop oxia");
+    let restarter = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        container.start().await.expect("restart oxia");
+        container
+    });
+
+    // Every write must eventually succeed.
+    let mut succeeded = 0;
+    while let Some(result) = tasks.join_next().await {
+        result.unwrap().unwrap();
+        succeeded += 1;
+    }
+    assert_eq!(succeeded, 50);
+
+    let _container = restarter.await.unwrap();
+
+    // Spot-check that writes actually landed with the right values.
+    for i in [0usize, 25, 49] {
+        let got = client.get(format!("load/{i:02}")).await.unwrap();
+        assert_eq!(got.value.as_deref(), Some(format!("v{i}").as_bytes()));
+    }
+    client.close().await.unwrap();
+}


### PR DESCRIPTION
## What (roadmap P1-G — Phase 1 gate)

Rounds out the Phase 1 resilience gate. Two new end-to-end failure tests run against a real `oxia standalone`, on top of the coverage already in the suite.

### New tests
- **`test_notifications_resume_after_server_restart`** — subscribe, receive a change, bounce the server, then confirm a change made *after* the server returns is still delivered. Exercises the per-shard listener reconnecting and resuming from its last delivered offset (P1-13/P1-14).
- **`test_writes_survive_restart_under_concurrent_load`** — fire 50 concurrent writes, stop the server while they're in flight, restart it, and assert every write eventually succeeds (with a value spot-check). Exercises the batcher's requeue-and-retry path under concurrency (P1-11).

### Gate coverage map (documented in a section comment)
| Scenario | Coverage |
|---|---|
| cluster-down fail-fast | `build_fails_fast_when_cluster_unreachable` |
| leader restart mid-operation | `test_operations_survive_server_restart` |
| leader restart under load | **new** — `test_writes_survive_restart_under_concurrent_load` |
| notification resume after reconnect | **new** — `test_notifications_resume_after_server_restart` |
| session cleanup on close | `test_ephemeral_keys` |

### Two scenarios that can't be driven against the standalone

I investigated both empirically; neither is reachable through the standalone container, so they stay covered at the unit/logic level (as the Go/Java clients do):

- **Live shard split/merge under load.** The `oxia standalone` binds only the public service (6648) and metrics (8080) — it runs no coordinator/admin service, and `oxia standalone --help` exposes no split. `docker exec … oxia admin shard split` fails with `connection refused` on the admin port (6651). So `OxiaAdmin.SplitShard` is unreachable and no live split can be triggered. The re-routing logic (`SHARD_NOT_FOUND` → re-hash + resubmit) is unit-tested in `client.rs` (P1-12).
- **Forced session expiry.** The server persists sessions (`sessionManager.Initialize` → `readSessions`) and, on restart, recovers them with a fresh heartbeat timer while the client transparently resumes keep-alive — so `SESSION_NOT_FOUND` can't be provoked through the public API without a failure-injection hook the standalone doesn't offer. The recreate-on-expiry path (keep-alive marks the session dead → next ephemeral op opens a fresh session) is covered by the P1-6/P1-7 session-manager logic.

A live cluster (separate coordinator + dataservers) would be needed to drive those two; happy to add a heavier multi-node harness in a follow-up if you'd like them as live tests.

## Verification
`fmt` + `clippy --all-targets -D warnings` clean; unit (48), doc (12), integration (**54**), interop (2) all green — full integration suite passes under default parallelism (no fixed-port collisions).