### PR TITLE
feat: validate sequence-key put options client-side (match Java)

### DIFF
--- a/oxia-client/src/client.rs
+++ b/oxia-client/src/client.rs
@@ -201,6 +201,10 @@ impl OxiaClient {
     /// # Errors
     ///
     /// Awaiting the builder returns:
+    /// - [`OxiaError::InvalidArgument`] when
+    ///   [`sequence_key_deltas`](PutBuilder::sequence_key_deltas) is used
+    ///   without a partition key, with a zero delta, or together with an
+    ///   expected version;
     /// - [`OxiaError::UnexpectedVersionId`] when a
     ///   [`expected_version_id`](PutBuilder::expected_version_id) /
     ///   [`expected_record_not_exists`](PutBuilder::expected_record_not_exists)

--- a/oxia-client/src/requests.rs
+++ b/oxia-client/src/requests.rs
@@ -68,8 +68,13 @@ impl PutBuilder {
     }
 
     /// Turns the key into a server-generated sequential key: each delta is
-    /// added to the current highest sequence and appended as a suffix.
-    /// Requires [`partition_key`](PutBuilder::partition_key).
+    /// added to the current highest sequence and appended as a zero-padded
+    /// suffix.
+    ///
+    /// Requires [`partition_key`](PutBuilder::partition_key); every delta must
+    /// be greater than zero; and it cannot be combined with
+    /// [`expected_version_id`](PutBuilder::expected_version_id). Awaiting a put
+    /// that violates any of these fails with [`OxiaError::InvalidArgument`].
     pub fn sequence_key_deltas(mut self, deltas: impl IntoIterator<Item = u64>) -> Self {
         self.sequence_key_deltas = deltas.into_iter().collect();
         self
@@ -99,6 +104,27 @@ impl PutBuilder {
     async fn execute(self) -> Result<PutResult, OxiaError> {
         let client = self.client;
         client.ensure_open()?;
+        // Validate sequence-key puts up front (matching the Java client's
+        // `PutOperation`): sequential keys require a partition key, are
+        // incompatible with an expected version, and every delta must be
+        // positive. Negative deltas are already impossible (`u64`).
+        if !self.sequence_key_deltas.is_empty() {
+            if self.partition_key.is_none() {
+                return Err(OxiaError::InvalidArgument(
+                    "sequence_key_deltas requires a partition_key".to_string(),
+                ));
+            }
+            if self.expected_version_id.is_some() {
+                return Err(OxiaError::InvalidArgument(
+                    "sequence_key_deltas cannot be combined with expected_version_id".to_string(),
+                ));
+            }
+            if self.sequence_key_deltas.contains(&0) {
+                return Err(OxiaError::InvalidArgument(
+                    "every sequence delta must be greater than zero".to_string(),
+                ));
+            }
+        }
         let routing_key = self
             .partition_key
             .as_deref()

--- a/oxia-client/tests/java_parity_tests.rs
+++ b/oxia-client/tests/java_parity_tests.rs
@@ -256,17 +256,46 @@ async fn test_partition_key() {
     client.close().await.unwrap();
 }
 
-/// Port of `OxiaClientIT.testSequentialKeys` (happy path): server-assigned keys
-/// are the base plus one zero-padded 20-digit segment per delta.
+/// Port of `OxiaClientIT.testSequentialKeys`: invalid sequence-key options are
+/// rejected client-side, and server-assigned keys are the base plus one
+/// zero-padded 20-digit segment per delta.
 ///
-/// The Java test also asserts four client-side validation errors
-/// (`IllegalArgumentException`) that this client does not yet enforce; that
-/// divergence is tracked separately, and negative deltas are already impossible
-/// here (`sequence_key_deltas` takes `u64`).
+/// The Java test's negative-delta case is not portable — `sequence_key_deltas`
+/// takes `u64`, so negatives cannot be expressed. Java throws
+/// `IllegalArgumentException` synchronously; this client returns
+/// `Err(InvalidArgument)` when the builder is awaited.
 #[tokio::test]
 async fn test_sequential_keys() {
     let (_container, address) = start_oxia().await;
     let client = new_client(&address).await;
+
+    // Sequential keys require a partition key.
+    assert!(matches!(
+        client
+            .put("sk_a", b"0".to_vec())
+            .sequence_key_deltas(vec![1])
+            .await,
+        Err(OxiaError::InvalidArgument(_))
+    ));
+    // A zero delta is rejected.
+    assert!(matches!(
+        client
+            .put("sk_a", b"0".to_vec())
+            .partition_key("x")
+            .sequence_key_deltas(vec![0])
+            .await,
+        Err(OxiaError::InvalidArgument(_))
+    ));
+    // Sequential keys cannot be combined with an expected version.
+    assert!(matches!(
+        client
+            .put("sk_a", b"0".to_vec())
+            .partition_key("x")
+            .sequence_key_deltas(vec![1])
+            .expected_version_id(1)
+            .await,
+        Err(OxiaError::InvalidArgument(_))
+    ));
 
     let r1 = client
         .put("sk_a", b"0".to_vec())


### PR DESCRIPTION
## What

Follow-up to #44 (the Java IT scenario ports), which surfaced this divergence. It landed on the branch just after #44 was merged, so it missed that PR.

Java rejects invalid sequence-key puts **synchronously** in `PutOperation`; this client forwarded them to the server. This aligns the behavior: awaiting a `put` with `sequence_key_deltas` now returns `OxiaError::InvalidArgument` when

- there is **no partition key**,
- a delta is **zero**, or
- it is combined with an **expected version** (`expected_version_id`).

Negative deltas remain impossible — `sequence_key_deltas` takes `u64`. (Java throws from `put()`; this client returns `Err` when the lazy builder is awaited — the idiomatic equivalent.)

## Details

- Validation added to `PutBuilder::execute`, before the request is dispatched.
- Documented on `sequence_key_deltas` and in `put`'s `# Errors`.
- `java_parity_tests::test_sequential_keys` (the port of `OxiaClientIT.testSequentialKeys`) now asserts all three rejections, completing the faithful port.

## Verification

`fmt` + `clippy --all-targets -D warnings` clean; unit, doc, and `java_parity_tests::test_sequential_keys` green. (The prior full `cargo test --workspace` — 48 unit / 54 integration / 2 interop / 12 java_parity / 12 doc — was green with this change on the #44 branch before the merge race.)