### PR TITLE
docs: overhaul README; add CONTRIBUTING, SECURITY, RELEASING (P5-3/P5-4)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to oxia-client-rust
+
+Thanks for contributing! This repository is the native Rust client SDK for
+[Oxia](https://github.com/oxia-db/oxia). Please be kind and respectful to the community —
+see the Oxia [Code of Conduct](https://github.com/oxia-db/oxia/blob/main/CODE_OF_CONDUCT.md).
+
+## Prerequisites
+
+- **Rust 1.85+** (edition 2024) — install via [rustup](https://rustup.rs). 1.85 is the MSRV;
+  please don't use features that raise it.
+- **protoc** — the Protocol Buffers compiler. The client generates gRPC code from `.proto`
+  files at build time.
+  - Debian/Ubuntu: `sudo apt-get install -y protobuf-compiler`
+  - macOS: `brew install protobuf`
+- **CMake** — required by a native build dependency. This repo pins it with
+  [mise](https://mise.jdx.dev): run `mise install` in the repo root, or install CMake yourself.
+- **Docker** — the integration and interop tests start a real Oxia server in a container
+  (`oxia/oxia:main`). Docker must be running to execute them.
+
+## Building and testing
+
+```shell
+cargo build --workspace
+cargo fmt --all -- --check                               # formatting
+cargo clippy --workspace --all-targets -- -D warnings    # lints — warnings are errors
+cargo test --workspace --lib --doc                       # fast unit + doc tests (no Docker)
+cargo test --workspace                                   # everything, incl. Docker-backed tests
+```
+
+The Docker-backed tests pull `oxia/oxia:main`. On a cold machine, pre-pull it to avoid a
+first-run delay and a concurrent-pull race:
+
+```shell
+docker pull oxia/oxia:main
+```
+
+Build the API docs locally with:
+
+```shell
+cargo doc -p oxia-client --no-deps --open
+```
+
+CI runs `fmt`, `clippy -D warnings`, `build`, the full test suite, and
+[`cargo-semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks); all must pass.
+
+## Submitting changes
+
+1. Fork the repository and create a feature branch off `main`.
+2. Keep changes focused and match the surrounding style. `cargo fmt` and
+   `cargo clippy --all-targets -- -D warnings` must be clean.
+3. Add tests for new behavior (unit tests, or integration tests under
+   `oxia-client/tests/` for server-observable behavior).
+4. **Sign off your commits.** This project requires a
+   [Developer Certificate of Origin](https://developercertificate.org/) sign-off — commit with
+   `git commit -s` (adds a `Signed-off-by` trailer). The DCO check will fail otherwise.
+5. Open a Pull Request with a clear description. Make sure CI is green.
+
+Have a question or an idea? Start a
+[discussion](https://github.com/oxia-db/oxia/discussions). All contributions are licensed under
+the Apache License 2.0.

--- a/README.md
+++ b/README.md
@@ -1,40 +1,114 @@
 # oxia-client-rust
 
-
 [![Crates.io][crates-badge]][crates-url]
+[![Docs.rs][docs-badge]][docs-url]
+[![CI][ci-badge]][ci-url]
+[![MSRV][msrv-badge]][msrv-url]
+[![License][license-badge]][license-url]
 
 [crates-badge]: https://img.shields.io/crates/v/oxia-client.svg
 [crates-url]: https://crates.io/crates/oxia-client
+[docs-badge]: https://img.shields.io/docsrs/oxia-client
+[docs-url]: https://docs.rs/oxia-client
+[ci-badge]: https://github.com/oxia-db/oxia-client-rust/actions/workflows/ci.yml/badge.svg
+[ci-url]: https://github.com/oxia-db/oxia-client-rust/actions/workflows/ci.yml
+[msrv-badge]: https://img.shields.io/badge/MSRV-1.85-blue.svg
+[msrv-url]: https://github.com/oxia-db/oxia-client-rust
+[license-badge]: https://img.shields.io/crates/l/oxia-client.svg
+[license-url]: ./LICENSE
 
-The native Rust client SDK for [Oxia](https://github.com/oxia-db/oxia), a distributed key-value store. Built on the
-Tokio asynchronous runtime, it offers an idiomatic and comprehensive API for managing data in Oxia, plus an optional C
-Foreign Function Interface (FFI) for integration with other languages.
+The native Rust client SDK for [Oxia](https://github.com/oxia-db/oxia), a distributed
+key-value and metadata store. Built on the [Tokio](https://tokio.rs) asynchronous runtime,
+it offers an idiomatic, comprehensive API — plus an optional C FFI for use from other
+languages.
+
+## Quickstart
+
+```toml
+[dependencies]
+oxia-client = "0.1"
+```
+
+```rust
+use oxia::{ComparisonType, OxiaClient};
+
+#[tokio::main]
+async fn main() -> Result<(), oxia::OxiaError> {
+    let client = OxiaClient::connect("localhost:6648").await?;
+
+    client.put("greeting", "hello").await?;
+    let record = client.get("greeting").await?;
+    assert_eq!(record.value.as_deref(), Some(b"hello".as_ref()));
+
+    client.close().await?;
+    Ok(())
+}
+```
+
+Every operation returns a builder you chain options onto and `.await`:
+
+```rust
+client.put("locks/w1", "").ephemeral().await?;
+let floor = client.get("config/z").comparison(ComparisonType::Floor).await?;
+let keys = client.list("users/", "users/~").await?;
+```
+
+See the [API documentation](https://docs.rs/oxia-client) for the full guide, and the
+runnable [examples](./oxia-client/examples).
+
+## Features
+
+Data-plane feature parity with the reference [Go](https://oxia-db.github.io/docs/clients/go)
+and [Java](https://oxia-db.github.io/docs/clients/java) clients:
+
+| Feature | Rust | Go | Java |
+|---|:--:|:--:|:--:|
+| Put / Get / Delete / Delete-range | ✅ | ✅ | ✅ |
+| Conditional writes (compare-and-swap) | ✅ | ✅ | ✅ |
+| Partition keys | ✅ | ✅ | ✅ |
+| Sequential keys | ✅ | ✅ | ✅ |
+| Secondary indexes | ✅ | ✅ | ✅ |
+| Ephemeral records & sessions | ✅ | ✅ | ✅ |
+| Notifications | ✅ | ✅ | ✅ |
+| Sequence updates | ✅ | ✅ | ✅ |
+| Floor / Ceiling / Lower / Higher get | ✅ | ✅ | ✅ |
+| List / Range scan (streaming) | ✅ | ✅ | ✅ |
+| Adaptive request batching | ✅ | ✅ | ✅ |
+| Automatic retries & shard re-routing | ✅ | ✅ | ✅ |
+| TLS | 🚧 | ✅ | ✅ |
+| Token authentication | 🚧 | ✅ | ✅ |
+| OpenTelemetry metrics | 🚧 | ✅ | ✅ |
+
+✅ supported · 🚧 planned
+
+## Compatibility
+
+The client speaks Oxia's `io.oxia.proto.v1` gRPC protocol and requires a server that serves
+it (current Oxia releases; CI runs against the `oxia/oxia:main` image). It does **not** support
+the legacy `io.streamnative.oxia.proto` service.
+
+| `oxia-client` | Oxia server | Rust toolchain |
+|---|---|---|
+| 0.1.x | serves `io.oxia.proto.v1` (recent releases) | 1.85+ (edition 2024) |
 
 ## Crates
 
-- **oxia-client**: The core, high-performance Rust client library (published to crates.io as `oxia-client`, imported as
-  `use oxia::...`). Built on the Tokio asynchronous runtime, it offers an idiomatic and comprehensive API for managing
-  data in Oxia.
-- **oxia-client-ffi**: A C Foreign Function Interface over `oxia-client`, exposing its functionality to C/C++
-  applications. The FFI layer manages data conversions and memory handling to bridge the Rust and C codebases.
+- **[oxia-client](./oxia-client)** — the core async Rust client (published to crates.io as
+  `oxia-client`, imported as `use oxia::…`).
+- **[oxia-client-ffi](./oxia-client-ffi)** — a C Foreign Function Interface over `oxia-client`,
+  exposing it to C/C++ applications.
 
-## Getting Started
+## Documentation
 
-Please check the examples directory for usage examples.
-
-- oxia-client: [oxia-client/examples](./oxia-client/examples)
-- oxia-client-ffi: [oxia-client-ffi/examples](./oxia-client-ffi/examples)
+- **API reference:** [docs.rs/oxia-client](https://docs.rs/oxia-client)
+- **Concept guide & per-SDK examples:** [Oxia documentation](https://oxia-db.github.io/docs/clients/rust)
 
 ## Contributing
 
-We welcome contributions from the community! To contribute to this project, please:
-
-1. Fork the repository and clone it locally.
-2. Create a new branch for your feature or bug fix.
-3. Submit a Pull Request (PR) with a clear description of your changes.
-
-All contributions submitted to this project will be licensed under the Apache License 2.0.
+Contributions are welcome — see [CONTRIBUTING.md](./CONTRIBUTING.md) for how to build, test, and
+submit changes, and [RELEASING.md](./RELEASING.md) for the release process. To report a security
+issue, see [SECURITY.md](./SECURITY.md).
 
 ## License
 
-This project is licensed under the Apache License 2.0. A copy of the license is included in the repository.
+Licensed under the [Apache License 2.0](./LICENSE).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,42 @@
+# Release process
+
+`oxia-client` is published to [crates.io](https://crates.io/crates/oxia-client) and announced as
+[GitHub Releases](https://github.com/oxia-db/oxia-client-rust/releases).
+
+**Release notes live in GitHub Releases** — this repository intentionally keeps no in-repo
+`CHANGELOG.md`.
+
+## Steps
+
+1. **Bump the version.** Update `version` in `oxia-client/Cargo.toml` and
+   `oxia-client-ffi/Cargo.toml` (keep the two crates in lockstep) and refresh `Cargo.lock`
+   (`cargo build`). Open a PR and merge it to `main`.
+
+2. **Tag the release** on the merge commit and push the tag:
+
+   ```shell
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+   Pushing a `v*` tag triggers the
+   [`release-cargo.yml`](./.github/workflows/release-cargo.yml) workflow, which runs the full
+   test suite and then `cargo publish`es `oxia-client`.
+
+3. **Publish the GitHub Release.** Draft a release for the tag (GitHub can auto-generate notes
+   from the merged PRs) and curate it into highlights, notable changes, and any migration notes,
+   then publish it.
+
+## Versioning
+
+The crate follows [Semantic Versioning](https://semver.org). CI runs
+[`cargo-semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks) against the latest
+published release to catch accidental breaking changes; the check self-arms once the first
+version is on crates.io.
+
+## crates.io token
+
+The publish step authenticates with the `CRATE_TOKEN` repository secret. It must be a crates.io
+API token with the **publish-new** scope (required to publish a crate name for the first time)
+and **publish-update** scope. If the token is crate-scoped, it must include `oxia-client`. A token
+lacking these scopes fails the publish with `403 Forbidden`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are provided for the latest `0.x` release line of `oxia-client`.
+
+| Version | Supported |
+|---|:--:|
+| 0.1.x | ✅ |
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or
+pull requests.**
+
+Instead, use GitHub's private vulnerability reporting: open the repository's **Security** tab and
+click **[Report a vulnerability](https://github.com/oxia-db/oxia-client-rust/security/advisories/new)**.
+This creates a private advisory visible only to the maintainers.
+
+Please include:
+
+- a description of the vulnerability and its potential impact,
+- steps to reproduce (a proof of concept if possible),
+- affected version(s), and
+- any suggested mitigation.
+
+We will acknowledge your report, keep you informed as we investigate, and coordinate a fix and
+disclosure timeline with you.


### PR DESCRIPTION
## What (roadmap P5-3 / P5-4)

Project-level documentation for the repo.

### P5-3 — README overhaul
- **Quickstart** — `cargo add` snippet + a minimal `connect`/`put`/`get`/`close` example, plus the builder-options style.
- **Feature table vs Go/Java** — data-plane parity matrix; TLS / token auth / OpenTelemetry metrics marked 🚧 planned (Phase 3), everything else ✅.
- **Compatibility matrix** — the client speaks `io.oxia.proto.v1` and needs a server that serves it (not the legacy `io.streamnative.oxia.proto`); Rust 1.85+.
- **Badges** — crates.io version, docs.rs, CI status, MSRV 1.85, license.

### P5-4 — project docs
- **CONTRIBUTING.md** — prerequisites (Rust 1.85, `protoc`, CMake via **mise**, Docker for the integration/interop tests), the exact build/test/lint/doc commands, and the **DCO sign-off** (`git commit -s`) + PR conventions.
- **SECURITY.md** — supported versions and **private vulnerability reporting** via GitHub security advisories (upstream Oxia has no SECURITY contact, so I didn't invent one).
- **RELEASING.md** — version bump → tag `vX.Y.Z` → `release-cargo.yml` publishes to crates.io; `cargo-semver-checks`; and the `CRATE_TOKEN` scope requirements (`publish-new`/`publish-update`) that the first publish needs.

### Note on CHANGELOG (P5-4 line item)
P5-4 lists "CHANGELOG", but per the earlier decision this repo keeps **no in-repo `CHANGELOG.md`** — release notes live in **GitHub Releases**. That's documented in RELEASING.md instead.

## Verification
Balanced code fences; all relative links resolve (LICENSE, the three new docs, crates, examples, workflows); tables well-formed. README quickstart mirrors the crate's compiling doctest.