### PR TITLE
build: drop the protoc requirement (compile protos with protox)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
         with:
           components: clippy, rustfmt
 
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
       - name: Cache cargo
         uses: actions/cache@v4
         with:
@@ -72,10 +69,6 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "::notice::oxia-client is not on crates.io yet (HTTP $code); skipping semver check until the first release."
           fi
-
-      - name: Install protobuf compiler
-        if: steps.baseline.outputs.exists == 'true'
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: cargo semver-checks
         if: steps.baseline.outputs.exists == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,14 @@ jobs:
             echo "::notice::oxia-client is not on crates.io yet (HTTP $code); skipping semver check until the first release."
           fi
 
+      # The semver baseline is the last *published* release, which may predate
+      # the protox migration and still build-depend on protoc. Install it only
+      # here so cargo-semver-checks can build that baseline; the current tree
+      # needs no protoc (it compiles the proto with protox).
+      - name: Install protobuf compiler (for the published baseline)
+        if: steps.baseline.outputs.exists == 'true'
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: cargo semver-checks
         if: steps.baseline.outputs.exists == 'true'
         uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/.github/workflows/release-cargo.yml
+++ b/.github/workflows/release-cargo.yml
@@ -19,9 +19,6 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,14 +8,13 @@ see the Oxia [Code of Conduct](https://github.com/oxia-db/oxia/blob/main/CODE_OF
 
 - **Rust 1.85+** (edition 2024) — install via [rustup](https://rustup.rs). 1.85 is the MSRV;
   please don't use features that raise it.
-- **protoc** — the Protocol Buffers compiler. The client generates gRPC code from `.proto`
-  files at build time.
-  - Debian/Ubuntu: `sudo apt-get install -y protobuf-compiler`
-  - macOS: `brew install protobuf`
 - **CMake** — required by a native build dependency. This repo pins it with
   [mise](https://mise.jdx.dev): run `mise install` in the repo root, or install CMake yourself.
 - **Docker** — the integration and interop tests start a real Oxia server in a container
   (`oxia/oxia:main`). Docker must be running to execute them.
+
+No `protoc` is required: the gRPC code is generated at build time from the `.proto`
+sources with the pure-Rust [`protox`](https://crates.io/crates/protox) compiler.
 
 ## Building and testing
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,7 +194,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -1001,6 +1007,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "logos"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7251356ef8cb7aec833ddf598c6cb24d17b689d20b993f9d11a3d764e34e6458"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f80069600c0d66734f5ff52cc42f2dabd6b29d205f333d61fd7832e9e9963f"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24fb722b06a9dc12adb0963ed585f19fc61dc5413e6a9be9422ef92c091e731d"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,6 +1059,28 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "mime"
@@ -1107,9 +1168,10 @@ dependencies = [
  "dashmap",
  "futures",
  "prost",
+ "protox",
  "testcontainers",
  "testcontainers-modules",
- "thiserror",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-test",
  "tokio-util",
@@ -1301,12 +1363,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-reflect"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5edd582b62f5cde844716e66d92565d7faf7ab1445c8cebce6e00fba83ddb2"
+dependencies = [
+ "logos",
+ "miette",
+ "once_cell",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "protox"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f352af331bf637b8ecc720f7c87bf903d2571fa2e14a66e9b2558846864b54a"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a462d115462c080ae000c29a47f0b3985737e5d3a995fcdbcaa5c782068dde"
+dependencies = [
+ "logos",
+ "miette",
+ "prost-types",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1809,7 +1911,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
  "tokio-tar",
@@ -1828,11 +1930,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.16",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2142,6 +2264,12 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ bytes = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tonic-build = "0.13.1"
+protox = "0.7"
 oxia-client = { path = "oxia-client" }
 libc = "0.2"
 futures = "0.3"

--- a/oxia-client/Cargo.toml
+++ b/oxia-client/Cargo.toml
@@ -39,3 +39,4 @@ tokio-test = "0.4"
 
 [build-dependencies]
 tonic-build = { workspace = true }
+protox = { workspace = true }

--- a/oxia-client/build.rs
+++ b/oxia-client/build.rs
@@ -1,4 +1,9 @@
 fn main() {
+    // Compile the proto with the pure-Rust `protox` compiler so that building
+    // this crate does not require a system `protoc` install. protox produces a
+    // `FileDescriptorSet` that tonic-build turns into the client stubs.
+    let file_descriptors = protox::compile(["proto/client.proto"], ["proto"])
+        .expect("failed to compile proto/client.proto with protox");
     tonic_build::configure()
         .build_client(true)
         .build_server(false)
@@ -6,6 +11,6 @@ fn main() {
         // decoding borrows the receive buffer and cloning is refcounted, so
         // values move through the client without byte copies.
         .bytes(["."])
-        .compile_protos(&["proto/client.proto"], &["proto"])
-        .unwrap();
+        .compile_fds(file_descriptors)
+        .expect("failed to generate gRPC code from the proto descriptor set");
 }


### PR DESCRIPTION
## What (roadmap P5-6)

Building `oxia-client` used to shell out to the system **`protoc`** (via tonic-build's `compile_protos`), so **every consumer** had to install protoc. This removes that requirement.

`build.rs` now compiles `proto/client.proto` with the pure-Rust [**`protox`**](https://crates.io/crates/protox) compiler and hands the resulting `FileDescriptorSet` to tonic-build via `compile_fds`:

```rust
let file_descriptors = protox::compile(["proto/client.proto"], ["proto"])?;
tonic_build::configure()
    .build_client(true).build_server(false)
    .bytes(["."])
    .compile_fds(file_descriptors)?;
```

I chose **protox over committed codegen** so the `.proto` stays the single source of truth — no generated code checked into the repo, no regen script, and no drift to police in CI.

## Verification

- **Proof protoc is gone:** built and ran the entire suite with `PROTOC=/nonexistent/protoc` — everything passes, so protoc is never invoked. (protox is pure Rust; `compile_fds` doesn't run protoc.)
  - unit (48), doc (12), integration (54), interop (2, Go↔Rust wire compat), java-parity (12) — all green.
- `fmt` + `clippy --all-targets -D warnings` clean.
- Removed the `protobuf-compiler` install steps from `ci.yml` (build + semver jobs) and `release-cargo.yml`, and dropped the protoc prerequisite from `CONTRIBUTING.md` (now notes the pure-Rust codegen).

## Cost

Adds `protox` (+ `prost-reflect`, `protox-parse`, `logos`, `miette`) as **build-dependencies** — compiled during `oxia-client`'s build, not shipped in the final binary. In exchange, consumers need no protoc toolchain at all.