### PR TITLE
feat: add oxia-perf load-testing CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +270,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +310,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +370,24 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -422,6 +542,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -592,6 +722,20 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom",
+ "num-traits",
+]
 
 [[package]]
 name = "heck"
@@ -930,6 +1074,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,12 +1239,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1113,6 +1270,16 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -1154,6 +1321,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,6 +1364,19 @@ dependencies = [
  "libc",
  "oxia-client",
  "tokio",
+]
+
+[[package]]
+name = "oxia-perf"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "hdrhistogram",
+ "oxia-client",
+ "rand",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1299,6 +1485,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1425,6 +1620,35 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.3",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1777,6 +2001,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2030,6 +2270,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "slab",
  "socket2 0.6.0",
  "tokio-macros",
@@ -2295,6 +2536,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -2692,6 +2939,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 members = [
     "oxia-client",
-    "oxia-client-ffi"
+    "oxia-client-ffi",
+    "oxia-perf"
 ]
 resolver = "2"
 
@@ -24,3 +25,6 @@ protox = "0.7"
 oxia-client = { path = "oxia-client" }
 libc = "0.2"
 futures = "0.3"
+clap = { version = "4", features = ["derive"] }
+hdrhistogram = "7"
+rand = "0.9"

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ the legacy `io.streamnative.oxia.proto` service.
   `oxia-client`, imported as `use oxia::…`).
 - **[oxia-client-ffi](./oxia-client-ffi)** — a C Foreign Function Interface over `oxia-client`,
   exposing it to C/C++ applications.
+- **[oxia-perf](./oxia-perf)** — a load-generation and latency-measurement CLI (like the Go and
+  Java SDKs' perf tools): drives a configurable read/write mix at a target rate and reports
+  throughput and latency percentiles. Run `cargo run -p oxia-perf -- --help`.
 
 ## Documentation
 

--- a/oxia-perf/Cargo.toml
+++ b/oxia-perf/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "oxia-perf"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+description = "A load-generation and latency-measurement CLI for the Oxia Rust client."
+license = "Apache-2.0"
+repository = "https://github.com/oxia-db/oxia-client-rust"
+publish = false
+
+[[bin]]
+name = "oxia-perf"
+path = "src/main.rs"
+
+[dependencies]
+oxia-client = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "signal"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+clap = { workspace = true }
+hdrhistogram = { workspace = true }
+rand = { workspace = true }

--- a/oxia-perf/src/main.rs
+++ b/oxia-perf/src/main.rs
@@ -1,0 +1,340 @@
+//! `oxia-perf` — a load-generation and latency-measurement CLI for the Oxia
+//! Rust client, mirroring the perf tools shipped with the Go and Java SDKs.
+//!
+//! It drives a configurable mix of reads and writes at a target rate against a
+//! set of keys, and reports throughput and latency percentiles every 10s (plus
+//! an aggregate summary on exit).
+
+use clap::Parser;
+use hdrhistogram::Histogram;
+use oxia::{Bytes, OxiaClient, OxiaError};
+use rand::RngCore;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio::time::MissedTickBehavior;
+use tracing::{info, warn};
+use tracing_subscriber::EnvFilter;
+
+/// How often interval stats are printed.
+const REPORT_INTERVAL: Duration = Duration::from_secs(10);
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "oxia-perf",
+    version,
+    about = "Load-generation and latency benchmarking for the Oxia Rust client"
+)]
+struct Args {
+    /// Oxia service address (host:port).
+    #[arg(short = 'a', long, default_value = "localhost:6648")]
+    service_address: String,
+
+    /// Oxia namespace.
+    #[arg(short = 'n', long, default_value = "default")]
+    namespace: String,
+
+    /// Total request rate, ops/s.
+    #[arg(short = 'r', long, default_value_t = 100.0)]
+    rate: f64,
+
+    /// Percentage of requests that are reads (the rest are writes).
+    #[arg(short = 'p', long = "read-write-percent", default_value_t = 80.0)]
+    read_percentage: f64,
+
+    /// Number of distinct keys the load is spread over.
+    #[arg(short = 'k', long, default_value_t = 1000)]
+    keys_cardinality: u32,
+
+    /// Value size in bytes.
+    #[arg(short = 's', long, default_value_t = 128)]
+    value_size: usize,
+
+    /// Generate a fresh random payload for every write.
+    #[arg(long)]
+    random_payload: bool,
+
+    /// Maximum number of requests per batch.
+    #[arg(long, default_value_t = 1000)]
+    max_requests_per_batch: u32,
+
+    /// Per-request timeout, in seconds.
+    #[arg(long, default_value_t = 30.0)]
+    request_timeout: f64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let args = Args::parse();
+    if !(0.0..=100.0).contains(&args.read_percentage) {
+        return Err("--read-write-percent must be between 0 and 100".into());
+    }
+    if args.keys_cardinality == 0 {
+        return Err("--keys-cardinality must be greater than 0".into());
+    }
+    info!(?args, "starting oxia-perf");
+
+    let client = OxiaClient::builder()
+        .service_address(&args.service_address)
+        .namespace(&args.namespace)
+        .max_requests_per_batch(args.max_requests_per_batch)
+        .request_timeout(Duration::from_secs_f64(args.request_timeout))
+        .build()
+        .await?;
+
+    let keys: Arc<Vec<String>> = Arc::new(
+        (0..args.keys_cardinality)
+            .map(|i| format!("key-{i}"))
+            .collect(),
+    );
+    let stats = Arc::new(Stats::new());
+
+    let mut generators = Vec::new();
+    let write_rate = args.rate * (100.0 - args.read_percentage) / 100.0;
+    if write_rate > 0.0 {
+        generators.push(tokio::spawn(write_traffic(
+            client.clone(),
+            keys.clone(),
+            stats.clone(),
+            write_rate,
+            args.value_size,
+            args.random_payload,
+        )));
+    }
+    let read_rate = args.rate * args.read_percentage / 100.0;
+    if read_rate > 0.0 {
+        generators.push(tokio::spawn(read_traffic(
+            client.clone(),
+            keys.clone(),
+            stats.clone(),
+            read_rate,
+        )));
+    }
+
+    let start = Instant::now();
+    let mut ticker = tokio::time::interval(REPORT_INTERVAL);
+    ticker.tick().await; // discard the immediate first tick
+    loop {
+        tokio::select! {
+            _ = ticker.tick() => stats.report_interval(),
+            _ = tokio::signal::ctrl_c() => {
+                println!("\nInterrupted, shutting down…");
+                break;
+            }
+        }
+    }
+
+    // Stop generating load before tearing the client down.
+    for generator in &generators {
+        generator.abort();
+    }
+    stats.report_summary(start.elapsed());
+    client.close().await?;
+    Ok(())
+}
+
+async fn write_traffic(
+    client: OxiaClient,
+    keys: Arc<Vec<String>>,
+    stats: Arc<Stats>,
+    rate: f64,
+    value_size: usize,
+    random_payload: bool,
+) {
+    let fixed: Bytes = Bytes::from(vec![0u8; value_size]);
+    let mut ticker = tokio::time::interval(Duration::from_secs_f64(1.0 / rate));
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    loop {
+        ticker.tick().await;
+        let key = keys[rand::random_range(0..keys.len())].clone();
+        let value: Bytes = if random_payload {
+            let mut v = vec![0u8; value_size];
+            rand::rng().fill_bytes(&mut v);
+            v.into()
+        } else {
+            fixed.clone()
+        };
+        let client = client.clone();
+        let stats = stats.clone();
+        tokio::spawn(async move {
+            let start = Instant::now();
+            match client.put(key.clone(), value).await {
+                Ok(_) => stats.record_write(elapsed_micros(start)),
+                // In flight while the client is closing on shutdown; not a failure.
+                Err(OxiaError::Closed) => {}
+                Err(err) => {
+                    warn!(key = %key, %err, "write failed");
+                    stats.record_failure();
+                }
+            }
+        });
+    }
+}
+
+async fn read_traffic(client: OxiaClient, keys: Arc<Vec<String>>, stats: Arc<Stats>, rate: f64) {
+    let mut ticker = tokio::time::interval(Duration::from_secs_f64(1.0 / rate));
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    loop {
+        ticker.tick().await;
+        let key = keys[rand::random_range(0..keys.len())].clone();
+        let client = client.clone();
+        let stats = stats.clone();
+        tokio::spawn(async move {
+            let start = Instant::now();
+            match client.get(key.clone()).await {
+                // A miss is a normal outcome for a read, not a failure.
+                Ok(_) | Err(OxiaError::KeyNotFound) => stats.record_read(elapsed_micros(start)),
+                // In flight while the client is closing on shutdown; not a failure.
+                Err(OxiaError::Closed) => {}
+                Err(err) => {
+                    warn!(key = %key, %err, "read failed");
+                    stats.record_failure();
+                }
+            }
+        });
+    }
+}
+
+fn elapsed_micros(start: Instant) -> u64 {
+    start.elapsed().as_micros().min(u64::MAX as u128) as u64
+}
+
+/// Latency histograms and counters shared by the traffic generators and the
+/// reporter. Interval histograms are reset each report and folded into the
+/// running totals for the final summary.
+struct Stats {
+    write: Mutex<Histogram<u64>>,
+    read: Mutex<Histogram<u64>>,
+    write_total: Mutex<Histogram<u64>>,
+    read_total: Mutex<Histogram<u64>>,
+    failed: AtomicU64,
+    failed_total: AtomicU64,
+}
+
+impl Stats {
+    fn new() -> Self {
+        let hist = || Mutex::new(Histogram::<u64>::new(3).expect("valid histogram config"));
+        Stats {
+            write: hist(),
+            read: hist(),
+            write_total: hist(),
+            read_total: hist(),
+            failed: AtomicU64::new(0),
+            failed_total: AtomicU64::new(0),
+        }
+    }
+
+    fn record_write(&self, micros: u64) {
+        record(&self.write, micros);
+    }
+
+    fn record_read(&self, micros: u64) {
+        record(&self.read, micros);
+    }
+
+    fn record_failure(&self) {
+        self.failed.fetch_add(1, Ordering::Relaxed);
+        self.failed_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn report_interval(&self) {
+        let secs = REPORT_INTERVAL.as_secs_f64();
+        let (w_ops, w) = drain(&self.write, &self.write_total);
+        let (r_ops, r) = drain(&self.read, &self.read_total);
+        let failed = self.failed.swap(0, Ordering::Relaxed) as f64 / secs;
+        let w_rate = w_ops as f64 / secs;
+        let r_rate = r_ops as f64 / secs;
+        println!(
+            "Stats - Total ops: {:6.1} ops/s - Failed ops: {:6.1} ops/s\n\
+             \x20       Write ops {:6.1} w/s  Latency ms: 50% {:5.1} - 95% {:5.1} - 99% {:5.1} - 99.9% {:5.1} - max {:6.1}\n\
+             \x20       Read  ops {:6.1} r/s  Latency ms: 50% {:5.1} - 95% {:5.1} - 99% {:5.1} - 99.9% {:5.1} - max {:6.1}",
+            w_rate + r_rate,
+            failed,
+            w_rate,
+            w[0],
+            w[1],
+            w[2],
+            w[3],
+            w[4],
+            r_rate,
+            r[0],
+            r[1],
+            r[2],
+            r[3],
+            r[4],
+        );
+    }
+
+    fn report_summary(&self, elapsed: Duration) {
+        // Fold the last (partial) interval into the totals.
+        fold(&self.write, &self.write_total);
+        fold(&self.read, &self.read_total);
+        let w = self.write_total.lock().expect("mutex");
+        let r = self.read_total.lock().expect("mutex");
+        let secs = elapsed.as_secs_f64().max(0.001);
+        let total = w.len() + r.len();
+        println!(
+            "\nAggregated over {:.0}s: {} ops ({} writes, {} reads), {} failed — {:.1} ops/s\n\
+             \x20  Write latency ms: p50 {:.1}  p95 {:.1}  p99 {:.1}  p99.9 {:.1}  max {:.1}\n\
+             \x20  Read  latency ms: p50 {:.1}  p95 {:.1}  p99 {:.1}  p99.9 {:.1}  max {:.1}",
+            secs,
+            total,
+            w.len(),
+            r.len(),
+            self.failed_total.load(Ordering::Relaxed),
+            total as f64 / secs,
+            ms(&w, 0.5),
+            ms(&w, 0.95),
+            ms(&w, 0.99),
+            ms(&w, 0.999),
+            max_ms(&w),
+            ms(&r, 0.5),
+            ms(&r, 0.95),
+            ms(&r, 0.99),
+            ms(&r, 0.999),
+            max_ms(&r),
+        );
+    }
+}
+
+fn record(hist: &Mutex<Histogram<u64>>, micros: u64) {
+    // hdrhistogram's lowest discernible value is 1; a sub-microsecond op clamps.
+    let _ = hist.lock().expect("mutex").record(micros.max(1));
+}
+
+fn ms(hist: &Histogram<u64>, quantile: f64) -> f64 {
+    hist.value_at_quantile(quantile) as f64 / 1000.0
+}
+
+fn max_ms(hist: &Histogram<u64>) -> f64 {
+    hist.max() as f64 / 1000.0
+}
+
+/// Reads the interval histogram's op count and latency percentiles (ms), folds
+/// it into the running total, and resets it for the next interval.
+fn drain(interval: &Mutex<Histogram<u64>>, total: &Mutex<Histogram<u64>>) -> (u64, [f64; 5]) {
+    let mut hist = interval.lock().expect("mutex");
+    let count = hist.len();
+    let percentiles = [
+        ms(&hist, 0.5),
+        ms(&hist, 0.95),
+        ms(&hist, 0.99),
+        ms(&hist, 0.999),
+        max_ms(&hist),
+    ];
+    let _ = total.lock().expect("mutex").add(&*hist);
+    hist.clear();
+    (count, percentiles)
+}
+
+fn fold(interval: &Mutex<Histogram<u64>>, total: &Mutex<Histogram<u64>>) {
+    let mut hist = interval.lock().expect("mutex");
+    let _ = total.lock().expect("mutex").add(&*hist);
+    hist.clear();
+}


### PR DESCRIPTION
## What

Adds **`oxia-perf`**, a load-generation and latency-measurement CLI, mirroring the perf tools shipped with the [Go](https://github.com/oxia-db/oxia/tree/main/cmd/perf) and Java SDKs. It's a new workspace binary crate (`publish = false`).

It drives a configurable read/write mix at a target rate against a fixed set of keys and reports throughput + latency percentiles every 10s, with an aggregate summary on Ctrl-C.

### Flags (matching the reference tools)
`--service-address` · `--namespace` · `--rate` (ops/s) · `--read-write-percent` · `--keys-cardinality` · `--value-size` · `--random-payload` · `--max-requests-per-batch` · `--request-timeout`

### Sample output
```
$ oxia-perf -a localhost:6648 -r 800 -p 60 -k 200
Stats - Total ops:  799.2 ops/s - Failed ops:    0.0 ops/s
        Write ops  319.7 w/s  Latency ms: 50%   1.0 - 95%   1.8 - 99%   2.6 - 99.9%   6.6 - max   13.8
        Read  ops  479.5 r/s  Latency ms: 50%   0.8 - 95%   1.7 - 99%   2.5 - 99.9%   4.4 - max    7.0
^C
Interrupted, shutting down…
Aggregated over 13s: 10366 ops (4146 writes, 6220 reads), 0 failed — 798.3 ops/s
   Write latency ms: p50 1.0  p95 1.8  p99 3.0  p99.9 16.6  max 29.0
   Read  latency ms: p50 0.8  p95 1.7  p99 2.6  p99.9 9.8  max 21.3
```

## Design

- **Two rate-limited traffic generators** (write / read), split by `--read-write-percent`. Each is paced by its own `tokio::time::interval` limiter; each op is spawned so latency reflects the server round-trip, not client-side queuing.
- **Latency via [HdrHistogram](https://crates.io/crates/hdrhistogram)** — interval histograms are reported and reset every 10s and folded into running totals for the summary.
- A read miss (`KeyNotFound`) is a normal outcome, not a failure (matches Go). On shutdown the generators are aborted before the client is closed, so no spurious in-flight failures.

## Verification

Smoke-tested end-to-end against a standalone `oxia/oxia:main`: the read/write split, rates, percentiles, `--random-payload`, and clean Ctrl-C shutdown all behave correctly (0 failures). `fmt` + `clippy --workspace --all-targets -D warnings` clean; existing crates unaffected.