### PR TITLE
build: optimize the release profile (LTO, single codegen unit, strip)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,10 @@ futures = "0.3"
 clap = { version = "4", features = ["derive"] }
 hdrhistogram = "7"
 rand = "0.9"
+
+# Optimize release builds (notably the oxia-perf benchmark binary): whole-program
+# LTO and a single codegen unit trade compile time for a faster, smaller binary.
+[profile.release]
+lto = true
+codegen-units = 1
+strip = true


### PR DESCRIPTION
Adds a `[profile.release]` to the workspace root that enables whole-program LTO, a single codegen unit, and symbol stripping.

This produces a faster, smaller release binary — most relevant for the `oxia-perf` benchmark tool, where a debug/less-optimized build would skew throughput and latency numbers. The `oxia-perf` binary shrinks from **5.7 MB → 3.2 MB**.

```toml
[profile.release]
lto = true
codegen-units = 1
strip = true
```

Trade-off: release builds compile more slowly (whole-program LTO). Verified `cargo build --release` succeeds and the binary runs.