### PR TITLE
feat: optional OpenTelemetry metrics behind the `otel` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      - name: Clippy (otel feature)
+        run: cargo clippy -p oxia-client --all-targets --features otel -- -D warnings
+
       - name: Build
         run: cargo build --workspace
 
@@ -46,6 +49,12 @@ jobs:
 
       - name: Run tests
         run: cargo test --workspace
+
+      # The default `cargo test` runs with the `otel` feature off, so the
+      # metrics path is never exercised above. Run just the metrics integration
+      # test with the feature on (the image is already pulled).
+      - name: Run metrics test (otel feature)
+        run: cargo test -p oxia-client --features otel --test integration_tests test_metrics_recorded_through_meter_provider
 
   semver:
     name: Semver checks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,156 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +362,19 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
 
 [[package]]
 name = "bollard"
@@ -354,6 +517,15 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "core-foundation"
@@ -515,6 +687,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +816,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +899,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,6 +972,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1105,6 +1341,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,6 +1400,9 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "logos"
@@ -1333,6 +1581,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.8.7",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "oxia-client"
 version = "0.1.0"
 dependencies = [
@@ -1340,6 +1624,8 @@ dependencies = [
  "bytes",
  "dashmap",
  "futures",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost",
  "protox",
  "testcontainers",
@@ -1373,11 +1659,17 @@ dependencies = [
  "clap",
  "hdrhistogram",
  "oxia-client",
- "rand",
+ "rand 0.9.5",
  "tokio",
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot_core"
@@ -1466,10 +1758,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.1",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1623,12 +1940,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1638,7 +1976,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2561,6 +2908,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "value-bag"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd4ec1eb1d240636e354a30110a1dfcb37047169a4d9bd6d9d3469df574b5c4"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2621,6 +2974,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2650,6 +3016,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ futures = "0.3"
 clap = { version = "4", features = ["derive"] }
 hdrhistogram = "7"
 rand = "0.9"
+opentelemetry = "0.27"
+opentelemetry_sdk = "0.27"
 
 # Optimize release builds (notably the oxia-perf benchmark binary): whole-program
 # LTO and a single codegen unit trade compile time for a faster, smaller binary.

--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ and [Java](https://oxia-db.github.io/docs/clients/java) clients:
 | Automatic retries & shard re-routing | ✅ | ✅ | ✅ |
 | TLS | 🚧 | ✅ | ✅ |
 | Token authentication | 🚧 | ✅ | ✅ |
-| OpenTelemetry metrics | 🚧 | ✅ | ✅ |
+| OpenTelemetry metrics | ✅¹ | ✅ | ✅ |
 
 ✅ supported · 🚧 planned
+
+¹ Behind the off-by-default `otel` Cargo feature.
 
 ## Compatibility
 

--- a/oxia-client/Cargo.toml
+++ b/oxia-client/Cargo.toml
@@ -36,6 +36,12 @@ opentelemetry = { workspace = true, optional = true }
 # OpenTelemetry metrics (meter `oxia_client`); off by default for a zero-cost build.
 otel = ["dep:opentelemetry"]
 
+# Build docs.rs with all optional features so the `otel` API is documented,
+# with "Available on crate feature otel" badges (see the `docsrs` cfg in lib.rs).
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dev-dependencies]
 tracing-subscriber = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["metrics", "testing", "rt-tokio"] }

--- a/oxia-client/Cargo.toml
+++ b/oxia-client/Cargo.toml
@@ -30,9 +30,15 @@ bytes = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
 tonic-types = { workspace = true }
+opentelemetry = { workspace = true, optional = true }
+
+[features]
+# OpenTelemetry metrics (meter `oxia_client`); off by default for a zero-cost build.
+otel = ["dep:opentelemetry"]
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["metrics", "testing", "rt-tokio"] }
 testcontainers = "0.23"
 testcontainers-modules = "0.11"
 tokio-test = "0.4"

--- a/oxia-client/src/client.rs
+++ b/oxia-client/src/client.rs
@@ -4,6 +4,7 @@ use crate::batcher::{BatcherDeps, ReadBatcher, WriteBatcher, WriteOp, pending_wr
 use crate::client_builder::OxiaClientBuilder;
 use crate::client_options::OxiaClientOptions;
 use crate::errors::OxiaError;
+use crate::metrics::Metrics;
 use crate::notification_manager::NotificationManager;
 use crate::operations::Pending;
 use crate::proto;
@@ -39,6 +40,7 @@ pub(crate) struct Inner {
     pub(crate) shard_manager: Arc<ShardManager>,
     pub(crate) session_manager: Arc<SessionManager>,
     batcher_deps: Arc<BatcherDeps>,
+    metrics: Metrics,
     notification_managers: DashMap<u64, NotificationManager>,
     sequence_managers: DashMap<u64, SequenceUpdatesManager>,
     next_subscription_id: AtomicU64,
@@ -142,7 +144,10 @@ impl OxiaClient {
             .await
     }
 
-    pub(crate) async fn new(options: OxiaClientOptions) -> Result<OxiaClient, OxiaError> {
+    pub(crate) async fn new(
+        options: OxiaClientOptions,
+        metrics: Metrics,
+    ) -> Result<OxiaClient, OxiaError> {
         let provider_manager = Arc::new(ProviderManager::new(options.request_timeout));
         let shard_manager = Arc::new(
             ShardManager::new(ShardManagerOptions {
@@ -178,6 +183,7 @@ impl OxiaClient {
                 shard_manager,
                 session_manager,
                 batcher_deps,
+                metrics,
                 notification_managers: DashMap::new(),
                 sequence_managers: DashMap::new(),
                 next_subscription_id: AtomicU64::new(0),
@@ -577,6 +583,10 @@ impl OxiaClient {
 
     pub(crate) fn request_timeout(&self) -> Duration {
         self.inner.options.request_timeout
+    }
+
+    pub(crate) fn metrics(&self) -> &Metrics {
+        &self.inner.metrics
     }
 
     pub(crate) fn identity(&self) -> &str {

--- a/oxia-client/src/client_builder.rs
+++ b/oxia-client/src/client_builder.rs
@@ -134,6 +134,7 @@ impl OxiaClientBuilder {
     /// under the meter named `oxia_client`. When unset, the global meter
     /// provider is used. Requires the `otel` feature.
     #[cfg(feature = "otel")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "otel")))]
     pub fn meter_provider(mut self, provider: &impl opentelemetry::metrics::MeterProvider) -> Self {
         self.meter = Some(crate::metrics::meter_from_provider(provider));
         self

--- a/oxia-client/src/client_builder.rs
+++ b/oxia-client/src/client_builder.rs
@@ -48,6 +48,8 @@ pub struct OxiaClientBuilder {
     session_timeout: Option<Duration>,
     session_keep_alive: Option<Duration>,
     request_timeout: Option<Duration>,
+    #[cfg(feature = "otel")]
+    meter: Option<opentelemetry::metrics::Meter>,
 }
 
 impl OxiaClientBuilder {
@@ -128,6 +130,15 @@ impl OxiaClientBuilder {
         self
     }
 
+    /// Records client metrics through the given OpenTelemetry meter provider,
+    /// under the meter named `oxia_client`. When unset, the global meter
+    /// provider is used. Requires the `otel` feature.
+    #[cfg(feature = "otel")]
+    pub fn meter_provider(mut self, provider: &impl opentelemetry::metrics::MeterProvider) -> Self {
+        self.meter = Some(crate::metrics::meter_from_provider(provider));
+        self
+    }
+
     fn assemble_options(self) -> OxiaClientOptions {
         let mut options = OxiaClientOptions::default();
         if let Some(service_address) = self.service_address {
@@ -171,13 +182,17 @@ impl OxiaClientBuilder {
     /// unreachable, the namespace does not exist, or the first shard
     /// assignments cannot be obtained.
     pub async fn build(self) -> Result<OxiaClient, OxiaError> {
+        #[cfg(feature = "otel")]
+        let metrics = crate::metrics::Metrics::new(self.meter.clone());
+        #[cfg(not(feature = "otel"))]
+        let metrics = crate::metrics::Metrics;
         let options = self.assemble_options();
         if options.max_write_batches_in_flight == 0 || options.max_read_batches_in_flight == 0 {
             return Err(OxiaError::InvalidArgument(
                 "max batches in flight must be at least 1".to_string(),
             ));
         }
-        OxiaClient::new(options).await
+        OxiaClient::new(options, metrics).await
     }
 }
 

--- a/oxia-client/src/client_builder.rs
+++ b/oxia-client/src/client_builder.rs
@@ -52,6 +52,17 @@ pub struct OxiaClientBuilder {
     meter: Option<opentelemetry::metrics::Meter>,
 }
 
+// An OpenTelemetry `Meter` wraps an `Arc<dyn InstrumentProvider>` that is not
+// itself unwind-safe, which would otherwise strip these auto traits from the
+// builder whenever `otel` is enabled — a spurious semver break, since the
+// builder is unwind-safe in the default build. Recording metrics across an
+// unwind boundary is safe, so assert them back. Only compiled with `otel`,
+// where the auto-derived impls no longer apply (so there is no conflict).
+#[cfg(feature = "otel")]
+impl std::panic::UnwindSafe for OxiaClientBuilder {}
+#[cfg(feature = "otel")]
+impl std::panic::RefUnwindSafe for OxiaClientBuilder {}
+
 impl OxiaClientBuilder {
     /// Creates a builder with all options at their defaults.
     pub fn new() -> Self {
@@ -200,6 +211,14 @@ impl OxiaClientBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // The builder must stay unwind-safe in every feature configuration; the
+    // `otel` meter field must not silently strip these auto traits (see the
+    // manual impls above). Compile-time only.
+    const _: fn() = || {
+        fn assert_unwind_safe<T: std::panic::UnwindSafe + std::panic::RefUnwindSafe>() {}
+        assert_unwind_safe::<OxiaClientBuilder>();
+    };
 
     #[test]
     fn keep_alive_defaults_to_a_tenth_of_the_session_timeout() {

--- a/oxia-client/src/lib.rs
+++ b/oxia-client/src/lib.rs
@@ -128,9 +128,16 @@
 //!
 //! # Cargo features
 //!
-//! This crate exposes no optional Cargo features; all functionality is always
-//! compiled in. (TLS, token authentication, and OpenTelemetry metrics are
-//! planned, and will be documented here when they land.)
+//! - **`otel`** *(off by default)* — records client metrics through
+//!   [OpenTelemetry](https://opentelemetry.io/). With the feature enabled,
+//!   per-operation latency and value sizes are reported under the `oxia_client`
+//!   meter; attach a meter provider with
+//!   [`OxiaClientBuilder::meter_provider`], or let the client fall back to the
+//!   global provider. Without it, metrics recording compiles to a zero-cost
+//!   no-op.
+//!
+//! TLS and token authentication are planned, and will be documented here when
+//! they land.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
@@ -148,6 +155,7 @@ mod client_options;
 mod errors;
 mod hash;
 mod key;
+mod metrics;
 mod notification_manager;
 mod operations;
 mod provider_manager;

--- a/oxia-client/src/lib.rs
+++ b/oxia-client/src/lib.rs
@@ -131,15 +131,17 @@
 //! - **`otel`** *(off by default)* — records client metrics through
 //!   [OpenTelemetry](https://opentelemetry.io/). With the feature enabled,
 //!   per-operation latency and value sizes are reported under the `oxia_client`
-//!   meter; attach a meter provider with
-//!   [`OxiaClientBuilder::meter_provider`], or let the client fall back to the
-//!   global provider. Without it, metrics recording compiles to a zero-cost
-//!   no-op.
+//!   meter; attach a meter provider with [`OxiaClientBuilder`]'s
+//!   `meter_provider` method, or let the client fall back to the global
+//!   provider. Without it, metrics recording compiles to a zero-cost no-op.
 //!
 //! TLS and token authentication are planned, and will be documented here when
 //! they land.
 
 #![forbid(unsafe_code)]
+// Render "Available on crate feature otel" badges on docs.rs (nightly-only
+// attribute, enabled solely under the `docsrs` cfg that docs.rs sets).
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 #![allow(clippy::result_large_err)]
 // A panic on wire data must never take down the caller's process: forbid

--- a/oxia-client/src/metrics.rs
+++ b/oxia-client/src/metrics.rs
@@ -1,0 +1,100 @@
+//! Optional OpenTelemetry metrics, mirroring the Go client's `oxia_client`
+//! meter. Enabled with the `otel` Cargo feature; without it, [`Metrics`] is a
+//! zero-cost no-op so recording costs nothing in the default build.
+//!
+//! Instruments (meter `oxia_client`), each carrying `type`
+//! (put / get / delete / delete_range) and `result` (success / failure)
+//! attributes:
+//! - `oxia_client_op` — operation latency, in milliseconds.
+//! - `oxia_client_op_value` — operation value size, in bytes.
+
+#[cfg(feature = "otel")]
+pub(crate) use otel::Metrics;
+
+#[cfg(not(feature = "otel"))]
+pub(crate) use noop::Metrics;
+
+#[cfg(feature = "otel")]
+mod otel {
+    use opentelemetry::KeyValue;
+    use opentelemetry::metrics::{Histogram, Meter, MeterProvider};
+    use std::time::Duration;
+
+    /// Records the client's per-operation metrics under the `oxia_client`
+    /// meter. Cheap to clone — the histograms are `Arc`-backed handles.
+    #[derive(Clone)]
+    pub(crate) struct Metrics {
+        op_time: Histogram<f64>,
+        op_value: Histogram<u64>,
+    }
+
+    impl Metrics {
+        /// Builds the instruments from `meter`, or the global meter provider
+        /// when none was configured (matching the Go client's default).
+        pub(crate) fn new(meter: Option<Meter>) -> Self {
+            let meter = meter.unwrap_or_else(|| opentelemetry::global::meter("oxia_client"));
+            Metrics {
+                op_time: meter
+                    .f64_histogram("oxia_client_op")
+                    .with_unit("ms")
+                    .with_description("Latency of client operations")
+                    .build(),
+                op_value: meter
+                    .u64_histogram("oxia_client_op_value")
+                    .with_unit("By")
+                    .with_description("Value size of client operations")
+                    .build(),
+            }
+        }
+
+        /// Records a completed operation: its `op_type`, latency, and outcome.
+        /// `value_size` is recorded only when the operation carries a value
+        /// (a put's value, or a get's response value).
+        pub(crate) fn record_op(
+            &self,
+            op_type: &'static str,
+            latency: Duration,
+            value_size: Option<usize>,
+            ok: bool,
+        ) {
+            let attrs = [
+                KeyValue::new("type", op_type),
+                KeyValue::new("result", if ok { "success" } else { "failure" }),
+            ];
+            self.op_time.record(latency.as_secs_f64() * 1000.0, &attrs);
+            if let Some(size) = value_size {
+                self.op_value.record(size as u64, &attrs);
+            }
+        }
+    }
+
+    /// Builds a [`Metrics`] from an OpenTelemetry meter provider, naming the
+    /// meter `oxia_client`. Used by the client builder's `meter_provider`.
+    pub(crate) fn meter_from_provider(provider: &impl MeterProvider) -> Meter {
+        provider.meter("oxia_client")
+    }
+}
+
+#[cfg(feature = "otel")]
+pub(crate) use otel::meter_from_provider;
+
+#[cfg(not(feature = "otel"))]
+mod noop {
+    use std::time::Duration;
+
+    /// No-op stand-in for [`super::Metrics`] when the `otel` feature is off.
+    #[derive(Clone, Default)]
+    pub(crate) struct Metrics;
+
+    impl Metrics {
+        #[inline]
+        pub(crate) fn record_op(
+            &self,
+            _op_type: &'static str,
+            _latency: Duration,
+            _value_size: Option<usize>,
+            _ok: bool,
+        ) {
+        }
+    }
+}

--- a/oxia-client/src/requests.rs
+++ b/oxia-client/src/requests.rs
@@ -141,49 +141,58 @@ impl PutBuilder {
             ..
         } = self;
         let identity = client.identity().to_string();
+        let value_size = value.len();
+        let start = std::time::Instant::now();
         // Re-resolve the shard and (for ephemeral puts) its session on each
         // attempt, so a split/merge re-routes to the new shard.
-        let response = client
-            .with_shard_retry(&routing_key, |shard| {
-                let client = client.clone();
-                let key = key.clone();
-                let value = value.clone();
-                let partition_key = partition_key.clone();
-                let sequence_key_deltas = sequence_key_deltas.clone();
-                let secondary_indexes = secondary_indexes.clone();
-                let identity = identity.clone();
-                async move {
-                    let session_id = if ephemeral {
-                        Some(client.session_id_for(shard).await?)
-                    } else {
-                        None
-                    };
-                    let request = proto::PutRequest {
-                        key,
-                        value,
-                        expected_version_id,
-                        session_id,
-                        client_identity: Some(identity),
-                        partition_key,
-                        sequence_key_delta: sequence_key_deltas,
-                        secondary_indexes,
-                        override_version_id: None,
-                        override_modifications_count: None,
-                    };
-                    client.submit_write(shard, request, WriteOp::Put).await
-                }
+        let op_result = async {
+            let response = client
+                .with_shard_retry(&routing_key, |shard| {
+                    let client = client.clone();
+                    let key = key.clone();
+                    let value = value.clone();
+                    let partition_key = partition_key.clone();
+                    let sequence_key_deltas = sequence_key_deltas.clone();
+                    let secondary_indexes = secondary_indexes.clone();
+                    let identity = identity.clone();
+                    async move {
+                        let session_id = if ephemeral {
+                            Some(client.session_id_for(shard).await?)
+                        } else {
+                            None
+                        };
+                        let request = proto::PutRequest {
+                            key,
+                            value,
+                            expected_version_id,
+                            session_id,
+                            client_identity: Some(identity),
+                            partition_key,
+                            sequence_key_delta: sequence_key_deltas,
+                            secondary_indexes,
+                            override_version_id: None,
+                            override_modifications_count: None,
+                        };
+                        client.submit_write(shard, request, WriteOp::Put).await
+                    }
+                })
+                .await?;
+            check_status(response.status)?;
+            let version = response
+                .version
+                .ok_or_else(|| OxiaError::Decode("missing version in put response".to_string()))?;
+            Ok(PutResult {
+                // The server returns the key only when it generated it
+                // (sequential keys).
+                key: response.key.unwrap_or(key),
+                version: version.into(),
             })
-            .await?;
-        check_status(response.status)?;
-        let version = response
-            .version
-            .ok_or_else(|| OxiaError::Decode("missing version in put response".to_string()))?;
-        Ok(PutResult {
-            // The server returns the key only when it generated it
-            // (sequential keys).
-            key: response.key.unwrap_or(key),
-            version: version.into(),
-        })
+        }
+        .await;
+        client
+            .metrics()
+            .record_op("put", start.elapsed(), Some(value_size), op_result.is_ok());
+        op_result
     }
 }
 
@@ -262,20 +271,32 @@ impl GetBuilder {
             comparison_type: self.comparison.to_proto() as i32,
             secondary_index_name: self.secondary_index_name,
         };
-        if single_shard {
-            let route_key = self.partition_key.unwrap_or_else(|| self.key.clone());
-            let response = client
-                .with_shard_retry(&route_key, |shard| {
-                    let client = client.clone();
-                    let request = request.clone();
-                    async move { client.submit_get(shard, request).await }
-                })
-                .await?;
-            check_status(response.status)?;
-            GetResult::from_proto(response, Some(self.key))
-        } else {
-            client.broadcast_get(request, self.comparison).await
+        let start = std::time::Instant::now();
+        let op_result: Result<GetResult, OxiaError> = async {
+            if single_shard {
+                let route_key = self.partition_key.unwrap_or_else(|| self.key.clone());
+                let response = client
+                    .with_shard_retry(&route_key, |shard| {
+                        let client = client.clone();
+                        let request = request.clone();
+                        async move { client.submit_get(shard, request).await }
+                    })
+                    .await?;
+                check_status(response.status)?;
+                GetResult::from_proto(response, Some(self.key))
+            } else {
+                client.broadcast_get(request, self.comparison).await
+            }
         }
+        .await;
+        let value_size = op_result
+            .as_ref()
+            .ok()
+            .and_then(|r| r.value.as_ref().map(|v| v.len()));
+        client
+            .metrics()
+            .record_op("get", start.elapsed(), value_size, op_result.is_ok());
+        op_result
     }
 }
 
@@ -351,14 +372,22 @@ impl DeleteBuilder {
             key: self.key,
             expected_version_id: self.expected_version_id,
         };
-        let response = client
-            .with_shard_retry(&routing_key, |shard| {
-                let client = client.clone();
-                let request = request.clone();
-                async move { client.submit_write(shard, request, WriteOp::Delete).await }
-            })
-            .await?;
-        check_status(response.status)
+        let start = std::time::Instant::now();
+        let op_result = async {
+            let response = client
+                .with_shard_retry(&routing_key, |shard| {
+                    let client = client.clone();
+                    let request = request.clone();
+                    async move { client.submit_write(shard, request, WriteOp::Delete).await }
+                })
+                .await?;
+            check_status(response.status)
+        }
+        .await;
+        client
+            .metrics()
+            .record_op("delete", start.elapsed(), None, op_result.is_ok());
+        op_result
     }
 }
 
@@ -410,23 +439,31 @@ impl DeleteRangeBuilder {
             start_inclusive: self.min_key_inclusive,
             end_exclusive: self.max_key_exclusive,
         };
-        match self.partition_key {
-            Some(partition_key) => {
-                let response = client
-                    .with_shard_retry(&partition_key, |shard| {
-                        let client = client.clone();
-                        let request = request.clone();
-                        async move {
-                            client
-                                .submit_write(shard, request, WriteOp::DeleteRange)
-                                .await
-                        }
-                    })
-                    .await?;
-                check_status(response.status)
+        let start = std::time::Instant::now();
+        let op_result = async {
+            match self.partition_key {
+                Some(partition_key) => {
+                    let response = client
+                        .with_shard_retry(&partition_key, |shard| {
+                            let client = client.clone();
+                            let request = request.clone();
+                            async move {
+                                client
+                                    .submit_write(shard, request, WriteOp::DeleteRange)
+                                    .await
+                            }
+                        })
+                        .await?;
+                    check_status(response.status)
+                }
+                None => client.broadcast_delete_range(request).await,
             }
-            None => client.broadcast_delete_range(request).await,
         }
+        .await;
+        client
+            .metrics()
+            .record_op("delete_range", start.elapsed(), None, op_result.is_ok());
+        op_result
     }
 }
 

--- a/oxia-client/tests/integration_tests.rs
+++ b/oxia-client/tests/integration_tests.rs
@@ -2009,3 +2009,91 @@ async fn test_writes_survive_restart_under_concurrent_load() {
     }
     client.close().await.unwrap();
 }
+
+// ============================================================
+// Metrics (otel feature)
+// ============================================================
+
+/// With the `otel` feature enabled, operations report through the configured
+/// OpenTelemetry meter provider under the `oxia_client` meter, mirroring the Go
+/// client's instrument names and `type` attribute.
+///
+/// Runs on a multi-thread runtime: the OpenTelemetry `PeriodicReader`'s
+/// `force_flush` blocks the caller until its background worker replies, which
+/// would deadlock a single-threaded runtime.
+#[cfg(feature = "otel")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_metrics_recorded_through_meter_provider() {
+    use opentelemetry_sdk::metrics::data::Histogram;
+    use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+    use opentelemetry_sdk::runtime;
+    use opentelemetry_sdk::testing::metrics::InMemoryMetricExporter;
+
+    let (_container, address) = start_oxia().await;
+
+    let exporter = InMemoryMetricExporter::default();
+    let reader = PeriodicReader::builder(exporter.clone(), runtime::Tokio).build();
+    let provider = SdkMeterProvider::builder().with_reader(reader).build();
+
+    let client = OxiaClientBuilder::new()
+        .service_address(address)
+        .request_timeout(Duration::from_secs(10))
+        .meter_provider(&provider)
+        .build()
+        .await
+        .unwrap();
+
+    // Exercise each op type so every `type` attribute is emitted.
+    client.put("metrics/key", b"hello".to_vec()).await.unwrap();
+    client.get("metrics/key").await.unwrap();
+    client.delete("metrics/key").await.unwrap();
+    client
+        .delete_range("metrics/".to_string(), "metrics/~".to_string())
+        .await
+        .unwrap();
+    client.close().await.unwrap();
+
+    provider.force_flush().unwrap();
+
+    let resource_metrics = exporter.get_finished_metrics().unwrap();
+    let oxia_scope = resource_metrics
+        .iter()
+        .flat_map(|rm| &rm.scope_metrics)
+        .find(|sm| sm.scope.name() == "oxia_client")
+        .expect("the oxia_client meter scope must be present");
+
+    let names: Vec<&str> = oxia_scope.metrics.iter().map(|m| m.name.as_ref()).collect();
+    assert!(
+        names.contains(&"oxia_client_op"),
+        "expected an oxia_client_op instrument, got {names:?}"
+    );
+    assert!(
+        names.contains(&"oxia_client_op_value"),
+        "expected an oxia_client_op_value instrument, got {names:?}"
+    );
+
+    // The op-latency histogram must carry a `type` attribute for every op run.
+    let op = oxia_scope
+        .metrics
+        .iter()
+        .find(|m| m.name == "oxia_client_op")
+        .unwrap();
+    let histogram = op
+        .data
+        .as_any()
+        .downcast_ref::<Histogram<f64>>()
+        .expect("oxia_client_op is an f64 histogram");
+    let mut types: Vec<String> = histogram
+        .data_points
+        .iter()
+        .filter_map(|dp| {
+            dp.attributes
+                .iter()
+                .find(|kv| kv.key.as_str() == "type")
+                .map(|kv| kv.value.as_str().into_owned())
+        })
+        .collect();
+    types.sort();
+    types.dedup();
+    assert_eq!(types, ["delete", "delete_range", "get", "put"]);
+}


### PR DESCRIPTION
## What

Adds optional OpenTelemetry client metrics, mirroring the Go client's `oxia_client` meter, behind a new **off-by-default `otel` Cargo feature**. With the feature off, metric recording compiles to a **zero-cost no-op** — no OTel dependency is pulled in and no code runs on the hot path.

This resolves the two roadmap items:
- **P3-3** — Metrics: op latency histograms, value sizes, error counters.
- **D-4** — Metrics facade decision → OpenTelemetry behind an `otel` feature (mirrors Go; no `metrics`-crate variant).

## Instruments

Under the `oxia_client` meter, each carrying `type` (`put` / `get` / `delete` / `delete_range`) and `result` (`success` / `failure`) attributes:

| Instrument | Kind | Unit | Meaning |
|---|---|---|---|
| `oxia_client_op` | histogram (f64) | ms | Operation latency |
| `oxia_client_op_value` | histogram (u64) | By | Operation value size |

Latency is measured **submit → complete**, so it includes the client's internal retries — matching the Go client's semantics. Only server round-trips are recorded; purely client-side validation rejections are not.

## Usage

```rust
use oxia::OxiaClient;

let client = OxiaClient::builder()
    .service_address("localhost:6648")
    .meter_provider(&my_otel_provider) // or omit to use the global provider
    .build()
    .await?;
```

Enable the feature:

```toml
[dependencies]
oxia-client = { version = "0.1", features = ["otel"] }
```

## Design notes

- The `Metrics` type is a feature-gated zero-cost abstraction: a real OTel implementation under `#[cfg(feature = "otel")]`, a no-op unit struct otherwise. The built `Metrics` (not the raw `Meter`) is threaded through `OxiaClient::new`, keeping the `Debug`-deriving options struct free of a non-`Debug` meter field.
- **Batch-level instruments (`oxia_client_batch_*`) are deliberately deferred** to a follow-up: threading dispatch time and sizes through the batcher's adaptive/requeue lifecycle is invasive, and op metrics already deliver the primary user-facing signal.

## Tests & CI

- New integration test `test_metrics_recorded_through_meter_provider` (feature-gated) runs real put/get/delete/delete_range against a container with an in-memory OTel reader and asserts the instruments and their `type` attributes. Runs on a multi-thread runtime — the `PeriodicReader`'s blocking `force_flush` would deadlock a single-threaded one.
- CI now also runs clippy and the metrics test with `--features otel`, so both feature states are covered.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings` (default **and** `--features otel`)
- `cargo test -p oxia-client --lib` (48) · `--doc` (12)
- metrics IT (`--features otel`) · default CRUD/delete ITs
- `RUSTDOCFLAGS="-D warnings" cargo doc --features otel`