### PR TITLE
feat: TLS connections behind the `tls` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
-      - name: Clippy (otel feature)
-        run: cargo clippy -p oxia-client --all-targets --features otel -- -D warnings
+      - name: Clippy (all features)
+        run: cargo clippy -p oxia-client --all-targets --all-features -- -D warnings
 
       - name: Build
         run: cargo build --workspace
@@ -50,11 +50,14 @@ jobs:
       - name: Run tests
         run: cargo test --workspace
 
-      # The default `cargo test` runs with the `otel` feature off, so the
-      # metrics path is never exercised above. Run just the metrics integration
-      # test with the feature on (the image is already pulled).
+      # The default `cargo test` runs with the optional features off, so their
+      # paths are never exercised above. Run the feature-gated tests explicitly
+      # (the image is already pulled).
       - name: Run metrics test (otel feature)
         run: cargo test -p oxia-client --features otel --test integration_tests test_metrics_recorded_through_meter_provider
+
+      - name: Run TLS tests (tls feature)
+        run: cargo test -p oxia-client --features tls --test tls_tests
 
   semver:
     name: Semver checks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,6 +1628,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "protox",
+ "rcgen",
  "testcontainers",
  "testcontainers-modules",
  "thiserror 2.0.16",
@@ -1707,6 +1708,16 @@ dependencies = [
  "regex-syntax",
  "structmeta",
  "syn",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -1998,6 +2009,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,6 +2136,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2715,8 +2740,10 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-native-certs",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -3293,6 +3320,15 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ hdrhistogram = "7"
 rand = "0.9"
 opentelemetry = "0.27"
 opentelemetry_sdk = "0.27"
+rcgen = { version = "0.13", default-features = false, features = ["crypto", "pem", "ring"] }
 
 # Optimize release builds (notably the oxia-perf benchmark binary): whole-program
 # LTO and a single codegen unit trade compile time for a faster, smaller binary.

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ and [Java](https://oxia-db.github.io/docs/clients/java) clients:
 | List / Range scan (streaming) | ✅ | ✅ | ✅ |
 | Adaptive request batching | ✅ | ✅ | ✅ |
 | Automatic retries & shard re-routing | ✅ | ✅ | ✅ |
-| TLS | 🚧 | ✅ | ✅ |
+| TLS | ✅¹ | ✅ | ✅ |
 | Token authentication | 🚧 | ✅ | ✅ |
 | OpenTelemetry metrics | ✅¹ | ✅ | ✅ |
 
 ✅ supported · 🚧 planned
 
-¹ Behind the off-by-default `otel` Cargo feature.
+¹ Behind an off-by-default Cargo feature (`tls` and `otel`, respectively).
 
 ## Compatibility
 

--- a/oxia-client/Cargo.toml
+++ b/oxia-client/Cargo.toml
@@ -35,6 +35,8 @@ opentelemetry = { workspace = true, optional = true }
 [features]
 # OpenTelemetry metrics (meter `oxia_client`); off by default for a zero-cost build.
 otel = ["dep:opentelemetry"]
+# TLS connections (rustls with the ring provider; OS trust roots by default).
+tls = ["tonic/tls-ring", "tonic/tls-native-roots"]
 
 # Build docs.rs with all optional features so the `otel` API is documented,
 # with "Available on crate feature otel" badges (see the `docsrs` cfg in lib.rs).
@@ -45,6 +47,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dev-dependencies]
 tracing-subscriber = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["metrics", "testing", "rt-tokio"] }
+rcgen = { workspace = true }
 testcontainers = "0.23"
 testcontainers-modules = "0.11"
 tokio-test = "0.4"

--- a/oxia-client/src/address.rs
+++ b/oxia-client/src/address.rs
@@ -1,6 +1,69 @@
+/// Normalizes a user- or server-supplied address into a dialable URI.
+/// `tls://` (the scheme used by the reference Go client) is an alias for
+/// `https://`; a bare `host:port` defaults to `http://`.
 pub(crate) fn ensure_protocol(raw_address: String) -> String {
+    if let Some(rest) = raw_address.strip_prefix("tls://") {
+        return format!("https://{}", rest);
+    }
     if raw_address.starts_with("http://") || raw_address.starts_with("https://") {
         return raw_address;
     }
     format!("http://{}", raw_address)
+}
+
+/// Rewrites an `http://` address to `https://`. Shard-assignment addresses
+/// arrive without a scheme and default to `http://`; when the client is
+/// configured for TLS every connection must dial `https://` instead.
+#[cfg(feature = "tls")]
+pub(crate) fn force_https(address: String) -> String {
+    match address.strip_prefix("http://") {
+        Some(rest) => format!("https://{}", rest),
+        None => address,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_addresses_default_to_http() {
+        assert_eq!(
+            ensure_protocol("localhost:6648".to_string()),
+            "http://localhost:6648"
+        );
+    }
+
+    #[test]
+    fn explicit_schemes_are_preserved() {
+        assert_eq!(
+            ensure_protocol("http://localhost:6648".to_string()),
+            "http://localhost:6648"
+        );
+        assert_eq!(
+            ensure_protocol("https://localhost:6648".to_string()),
+            "https://localhost:6648"
+        );
+    }
+
+    #[test]
+    fn tls_scheme_is_an_alias_for_https() {
+        assert_eq!(
+            ensure_protocol("tls://localhost:6648".to_string()),
+            "https://localhost:6648"
+        );
+    }
+
+    #[cfg(feature = "tls")]
+    #[test]
+    fn force_https_rewrites_only_http() {
+        assert_eq!(
+            force_https("http://localhost:6648".to_string()),
+            "https://localhost:6648"
+        );
+        assert_eq!(
+            force_https("https://localhost:6648".to_string()),
+            "https://localhost:6648"
+        );
+    }
 }

--- a/oxia-client/src/client.rs
+++ b/oxia-client/src/client.rs
@@ -148,7 +148,13 @@ impl OxiaClient {
         options: OxiaClientOptions,
         metrics: Metrics,
     ) -> Result<OxiaClient, OxiaError> {
+        #[cfg(not(feature = "tls"))]
         let provider_manager = Arc::new(ProviderManager::new(options.request_timeout));
+        #[cfg(feature = "tls")]
+        let provider_manager = Arc::new(
+            ProviderManager::new(options.request_timeout)
+                .with_tls(options.tls.as_ref().map(|tls| tls.to_client_tls_config())),
+        );
         let shard_manager = Arc::new(
             ShardManager::new(ShardManagerOptions {
                 address: options.service_address.clone(),

--- a/oxia-client/src/client_builder.rs
+++ b/oxia-client/src/client_builder.rs
@@ -50,6 +50,8 @@ pub struct OxiaClientBuilder {
     request_timeout: Option<Duration>,
     #[cfg(feature = "otel")]
     meter: Option<opentelemetry::metrics::Meter>,
+    #[cfg(feature = "tls")]
+    tls: Option<crate::tls::TlsOptions>,
 }
 
 // An OpenTelemetry `Meter` wraps an `Arc<dyn InstrumentProvider>` that is not
@@ -151,6 +153,18 @@ impl OxiaClientBuilder {
         self
     }
 
+    /// Connects with TLS, using the given [`TlsOptions`](crate::TlsOptions).
+    /// Requires the `tls` feature.
+    ///
+    /// TLS is also enabled — with default options, verifying against the
+    /// system trust roots — by an `https://` (or `tls://`) service address.
+    #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
+    pub fn tls(mut self, tls: crate::tls::TlsOptions) -> Self {
+        self.tls = Some(tls);
+        self
+    }
+
     fn assemble_options(self) -> OxiaClientOptions {
         let mut options = OxiaClientOptions::default();
         if let Some(service_address) = self.service_address {
@@ -185,6 +199,18 @@ impl OxiaClientBuilder {
         if let Some(request_timeout) = self.request_timeout {
             options.request_timeout = request_timeout;
         }
+        // An https:// (or tls://, normalized to https:// on entry) service
+        // address implies TLS with default options, matching the Go client's
+        // `tls://` handling.
+        #[cfg(feature = "tls")]
+        {
+            options.tls = self.tls.or_else(|| {
+                options
+                    .service_address
+                    .starts_with("https://")
+                    .then(crate::tls::TlsOptions::new)
+            });
+        }
         options
     }
 
@@ -202,6 +228,14 @@ impl OxiaClientBuilder {
         if options.max_write_batches_in_flight == 0 || options.max_read_batches_in_flight == 0 {
             return Err(OxiaError::InvalidArgument(
                 "max batches in flight must be at least 1".to_string(),
+            ));
+        }
+        // Without the `tls` feature an https:// dial would only fail deep in
+        // the transport; reject it up front with an actionable message.
+        #[cfg(not(feature = "tls"))]
+        if options.service_address.starts_with("https://") {
+            return Err(OxiaError::InvalidArgument(
+                "TLS service address requires the `tls` Cargo feature".to_string(),
             ));
         }
         OxiaClient::new(options, metrics).await

--- a/oxia-client/src/client_options.rs
+++ b/oxia-client/src/client_options.rs
@@ -24,6 +24,9 @@ pub struct OxiaClientOptions {
     pub session_keep_alive: Duration,
     /// Timeout for individual requests (default: 30s).
     pub request_timeout: Duration,
+    /// TLS settings; `None` connects in plaintext (default).
+    #[cfg(feature = "tls")]
+    pub tls: Option<crate::tls::TlsOptions>,
 }
 
 impl Default for OxiaClientOptions {
@@ -39,6 +42,8 @@ impl Default for OxiaClientOptions {
             session_timeout: Duration::from_secs(15),
             session_keep_alive: Duration::from_secs(15) / 10,
             request_timeout: Duration::from_secs(30),
+            #[cfg(feature = "tls")]
+            tls: None,
         }
     }
 }

--- a/oxia-client/src/lib.rs
+++ b/oxia-client/src/lib.rs
@@ -134,9 +134,15 @@
 //!   meter; attach a meter provider with [`OxiaClientBuilder`]'s
 //!   `meter_provider` method, or let the client fall back to the global
 //!   provider. Without it, metrics recording compiles to a zero-cost no-op.
+//! - **`tls`** *(off by default)* — TLS connections via
+//!   [rustls](https://github.com/rustls/rustls). Enabled by an `https://` (or
+//!   `tls://`) service address, which verifies the server against the system
+//!   trust roots; a custom CA, a client certificate (mutual TLS), or a
+//!   domain-name override are configured with [`OxiaClientBuilder`]'s `tls`
+//!   method (see `TlsOptions`).
 //!
-//! TLS and token authentication are planned, and will be documented here when
-//! they land.
+//! Token authentication is planned, and will be documented here when it
+//! lands.
 
 #![forbid(unsafe_code)]
 // Render "Available on crate feature otel" badges on docs.rs (nightly-only
@@ -168,6 +174,8 @@ mod server_error;
 mod session_manager;
 mod shard_manager;
 mod streams;
+#[cfg(feature = "tls")]
+mod tls;
 mod types;
 
 #[allow(
@@ -189,4 +197,7 @@ pub use requests::{
     RangeScanBuilder, SequenceUpdatesBuilder,
 };
 pub use streams::{ListStream, Notifications, RangeScanStream, SequenceUpdates};
+#[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
+pub use tls::TlsOptions;
 pub use types::{ComparisonType, GetResult, Notification, PutResult, Version};

--- a/oxia-client/src/provider_manager.rs
+++ b/oxia-client/src/provider_manager.rs
@@ -18,6 +18,8 @@ const KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(3);
 pub struct ProviderManager {
     providers: Arc<DashMap<String, OnceCell<OxiaClientClient<Channel>>>>,
     connect_timeout: Duration,
+    #[cfg(feature = "tls")]
+    tls: Option<tonic::transport::ClientTlsConfig>,
 }
 
 impl ProviderManager {
@@ -27,15 +29,30 @@ impl ProviderManager {
     ) -> Result<OxiaClientClient<Channel>, OxiaError> {
         let once_cell = self.providers.entry(address.clone()).or_default();
         let connect_timeout = self.connect_timeout;
+        #[cfg(feature = "tls")]
+        let tls = self.tls.clone();
         let client = once_cell
             .get_or_try_init(|| async move {
-                let channel = Endpoint::from_shared(address)?
+                // With TLS configured, every dial — the bootstrap address and
+                // the scheme-less shard-leader addresses that defaulted to
+                // http:// — must go over https://.
+                #[cfg(feature = "tls")]
+                let address = if tls.is_some() {
+                    crate::address::force_https(address)
+                } else {
+                    address
+                };
+                let endpoint = Endpoint::from_shared(address)?
                     .connect_timeout(connect_timeout)
                     .keep_alive_while_idle(true)
                     .http2_keep_alive_interval(KEEP_ALIVE_INTERVAL)
-                    .keep_alive_timeout(KEEP_ALIVE_TIMEOUT)
-                    .connect()
-                    .await?;
+                    .keep_alive_timeout(KEEP_ALIVE_TIMEOUT);
+                #[cfg(feature = "tls")]
+                let endpoint = match tls {
+                    Some(tls) => endpoint.tls_config(tls)?,
+                    None => endpoint,
+                };
+                let channel = endpoint.connect().await?;
                 Ok::<OxiaClientClient<Channel>, OxiaError>(OxiaClientClient::new(channel))
             })
             .await?
@@ -47,7 +64,16 @@ impl ProviderManager {
         ProviderManager {
             providers: Arc::new(DashMap::new()),
             connect_timeout,
+            #[cfg(feature = "tls")]
+            tls: None,
         }
+    }
+
+    /// Applies a TLS configuration to every connection this manager creates.
+    #[cfg(feature = "tls")]
+    pub fn with_tls(mut self, tls: Option<tonic::transport::ClientTlsConfig>) -> ProviderManager {
+        self.tls = tls;
+        self
     }
 
     /// Drops all cached connections.

--- a/oxia-client/src/tls.rs
+++ b/oxia-client/src/tls.rs
@@ -1,0 +1,100 @@
+//! TLS configuration for connecting to a TLS-enabled Oxia cluster. Enabled
+//! with the `tls` Cargo feature.
+
+use tonic::transport::{Certificate, ClientTlsConfig, Identity};
+
+/// TLS settings for the client's connections, passed to
+/// [`OxiaClientBuilder::tls`](crate::OxiaClientBuilder::tls).
+///
+/// The default configuration ([`TlsOptions::new`]) verifies the server
+/// certificate against the operating system's trusted root store. Options
+/// mirror the reference Go client's TLS configuration:
+///
+/// - [`trusted_ca_pem`](TlsOptions::trusted_ca_pem) — trust a custom CA
+///   *instead of* the system roots (e.g. a self-signed cluster CA).
+/// - [`identity_pem`](TlsOptions::identity_pem) — present a client
+///   certificate (mutual TLS).
+/// - [`domain_name`](TlsOptions::domain_name) — override the name the server
+///   certificate is verified against (and the SNI sent), when the dialed
+///   address differs from the certificate's subject.
+///
+/// ```no_run
+/// # async fn example() -> Result<(), oxia::OxiaError> {
+/// use oxia::{OxiaClient, TlsOptions};
+///
+/// let ca_pem = std::fs::read("ca.crt").expect("read CA certificate");
+/// let client = OxiaClient::builder()
+///     .service_address("https://oxia.example.com:6648")
+///     .tls(TlsOptions::new().trusted_ca_pem(ca_pem))
+///     .build()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone, Default)]
+#[must_use = "TlsOptions must be passed to OxiaClientBuilder::tls"]
+pub struct TlsOptions {
+    ca_pem: Option<Vec<u8>>,
+    identity_pem: Option<(Vec<u8>, Vec<u8>)>,
+    domain_name: Option<String>,
+}
+
+impl TlsOptions {
+    /// TLS with default settings: the server certificate is verified against
+    /// the operating system's trusted root store.
+    pub fn new() -> Self {
+        TlsOptions::default()
+    }
+
+    /// Trusts the given PEM-encoded CA certificate(s) for verifying the
+    /// server, *instead of* the operating system's root store.
+    pub fn trusted_ca_pem(mut self, ca_pem: impl Into<Vec<u8>>) -> Self {
+        self.ca_pem = Some(ca_pem.into());
+        self
+    }
+
+    /// Presents the given PEM-encoded certificate and private key as the
+    /// client's identity (mutual TLS).
+    pub fn identity_pem(
+        mut self,
+        cert_pem: impl Into<Vec<u8>>,
+        key_pem: impl Into<Vec<u8>>,
+    ) -> Self {
+        self.identity_pem = Some((cert_pem.into(), key_pem.into()));
+        self
+    }
+
+    /// Verifies the server certificate against this name (and sends it as
+    /// SNI) instead of the host in the dialed address.
+    pub fn domain_name(mut self, domain_name: impl Into<String>) -> Self {
+        self.domain_name = Some(domain_name.into());
+        self
+    }
+
+    /// Builds the tonic TLS configuration applied to every connection.
+    pub(crate) fn to_client_tls_config(&self) -> ClientTlsConfig {
+        let mut config = ClientTlsConfig::new();
+        config = match &self.ca_pem {
+            Some(pem) => config.ca_certificate(Certificate::from_pem(pem)),
+            None => config.with_native_roots(),
+        };
+        if let Some((cert, key)) = &self.identity_pem {
+            config = config.identity(Identity::from_pem(cert, key));
+        }
+        if let Some(domain) = &self.domain_name {
+            config = config.domain_name(domain);
+        }
+        config
+    }
+}
+
+// Manual Debug: never print certificate or private-key material.
+impl std::fmt::Debug for TlsOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TlsOptions")
+            .field("custom_ca", &self.ca_pem.is_some())
+            .field("client_identity", &self.identity_pem.is_some())
+            .field("domain_name", &self.domain_name)
+            .finish()
+    }
+}

--- a/oxia-client/tests/tls_tests.rs
+++ b/oxia-client/tests/tls_tests.rs
@@ -1,0 +1,228 @@
+//! End-to-end TLS tests (feature `tls`).
+//!
+//! `oxia standalone` cannot serve TLS, so these tests run a minimal real
+//! cluster inside one container: an `oxia server` (dataserver) with TLS on its
+//! public port, plus an `oxia coordinator` — internal traffic stays plaintext.
+//! Certificates are generated per test with a throwaway CA, and the cluster
+//! config advertises the host-mapped public port so the shard-assignment
+//! addresses the client re-dials are reachable (and covered by the server
+//! certificate's `localhost` SAN).
+#![cfg(feature = "tls")]
+
+use oxia::{OxiaClient, OxiaClientBuilder, TlsOptions};
+use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, KeyPair};
+use std::time::{Duration, Instant};
+use testcontainers::core::ports::ContainerPort;
+use testcontainers::core::wait::WaitFor;
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, GenericImage, ImageExt};
+
+const OXIA_PORT: u16 = 6648;
+const DEFAULT_OXIA_IMAGE: &str = "oxia/oxia";
+const DEFAULT_OXIA_TAG: &str = "main";
+
+struct TestCerts {
+    ca_pem: String,
+    server_cert_pem: String,
+    server_key_pem: String,
+    client_cert_pem: String,
+    client_key_pem: String,
+}
+
+/// A throwaway CA, a server certificate for `localhost`/`127.0.0.1`, and a
+/// client certificate (for mutual TLS), all freshly generated.
+fn generate_certs() -> TestCerts {
+    let ca_key = KeyPair::generate().unwrap();
+    let mut ca_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    ca_params
+        .distinguished_name
+        .push(DnType::CommonName, "oxia-test-ca");
+    let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+
+    let server_key = KeyPair::generate().unwrap();
+    let server_cert =
+        CertificateParams::new(vec!["localhost".to_string(), "127.0.0.1".to_string()])
+            .unwrap()
+            .signed_by(&server_key, &ca_cert, &ca_key)
+            .unwrap();
+
+    let client_key = KeyPair::generate().unwrap();
+    let client_cert = CertificateParams::new(vec!["oxia-test-client".to_string()])
+        .unwrap()
+        .signed_by(&client_key, &ca_cert, &ca_key)
+        .unwrap();
+
+    TestCerts {
+        ca_pem: ca_cert.pem(),
+        server_cert_pem: server_cert.pem(),
+        server_key_pem: server_key.serialize_pem(),
+        client_cert_pem: client_cert.pem(),
+        client_key_pem: client_key.serialize_pem(),
+    }
+}
+
+struct TlsCluster {
+    _container: ContainerAsync<GenericImage>,
+    address: String,
+}
+
+/// Starts the one-container TLS cluster. With `client_auth`, the server also
+/// requires and verifies a client certificate (mutual TLS).
+async fn start_tls_oxia(certs: &TestCerts, client_auth: bool) -> TlsCluster {
+    let image = std::env::var("OXIA_IMAGE").unwrap_or_else(|_| DEFAULT_OXIA_IMAGE.to_string());
+    let tag = std::env::var("OXIA_TAG").unwrap_or_else(|_| DEFAULT_OXIA_TAG.to_string());
+
+    // The advertised public address must be reachable from the host, so pin
+    // the host port up front and bake it into the cluster config.
+    let host_port = std::net::TcpListener::bind(("127.0.0.1", 0))
+        .expect("bind probe port")
+        .local_addr()
+        .expect("probe port addr")
+        .port();
+
+    let cluster_yaml = format!(
+        "namespaces:\n  \
+           - name: default\n    \
+             initialShardCount: 2\n    \
+             replicationFactor: 1\n\
+         servers:\n  \
+           - {{ public: \"localhost:{host_port}\", internal: \"localhost:6649\" }}\n"
+    );
+
+    let mut server_cmd = String::from(
+        "oxia server --public-addr 0.0.0.0:6648 --internal-addr 0.0.0.0:6649 \
+         --metrics-addr 0.0.0.0:8080 \
+         --tls-cert-file /oxia/tls/server.crt --tls-key-file /oxia/tls/server.key \
+         --wal-dir /tmp/wal --data-dir /tmp/db",
+    );
+    if client_auth {
+        server_cmd.push_str(" --tls-trusted-ca-file /oxia/tls/ca.crt --tls-client-auth");
+    }
+    let script = format!(
+        "{server_cmd} & \
+         oxia coordinator --conf /oxia/tls/cluster.yaml --internal-addr 0.0.0.0:6652 \
+         --public-addr 0.0.0.0:6651 --metrics-addr 0.0.0.0:8081 & \
+         wait"
+    );
+
+    let container = GenericImage::new(image, tag)
+        .with_wait_for(WaitFor::message_on_stdout("Started Grpc server"))
+        .with_mapped_port(host_port, ContainerPort::Tcp(OXIA_PORT))
+        .with_copy_to("/oxia/tls/ca.crt", certs.ca_pem.clone().into_bytes())
+        .with_copy_to(
+            "/oxia/tls/server.crt",
+            certs.server_cert_pem.clone().into_bytes(),
+        )
+        .with_copy_to(
+            "/oxia/tls/server.key",
+            certs.server_key_pem.clone().into_bytes(),
+        )
+        .with_copy_to("/oxia/tls/cluster.yaml", cluster_yaml.into_bytes())
+        .with_cmd(vec!["bash".to_string(), "-c".to_string(), script])
+        .start()
+        .await
+        .expect("Failed to start TLS Oxia cluster");
+
+    TlsCluster {
+        _container: container,
+        address: format!("https://localhost:{host_port}"),
+    }
+}
+
+/// Builds a client, retrying while the cluster elects its shard leaders.
+async fn connect_with_retry(address: &str, tls: TlsOptions) -> OxiaClient {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let result = OxiaClientBuilder::new()
+            .service_address(address.to_string())
+            .request_timeout(Duration::from_secs(5))
+            .tls(tls.clone())
+            .build()
+            .await;
+        match result {
+            Ok(client) => return client,
+            Err(e) => {
+                assert!(
+                    Instant::now() < deadline,
+                    "client could not connect over TLS before the deadline: {e}"
+                );
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        }
+    }
+}
+
+/// TLS end to end: handshake with a custom CA, operations across shards (the
+/// re-dialed shard-assignment addresses must also go over TLS), and rejection
+/// of a client that does not trust the cluster's CA.
+#[tokio::test]
+async fn test_tls_end_to_end() {
+    let certs = generate_certs();
+    let cluster = start_tls_oxia(&certs, false).await;
+
+    let tls = TlsOptions::new().trusted_ca_pem(certs.ca_pem.clone());
+    let client = connect_with_retry(&cluster.address, tls).await;
+
+    // Spread keys over both shards; every op crosses the TLS connection the
+    // client re-established from the advertised assignment addresses.
+    for i in 0..10 {
+        client
+            .put(format!("tls/key-{i}"), format!("value-{i}").into_bytes())
+            .await
+            .unwrap();
+    }
+    for i in 0..10 {
+        let got = client.get(format!("tls/key-{i}")).await.unwrap();
+        assert_eq!(got.value.as_deref(), Some(format!("value-{i}").as_bytes()));
+    }
+    let keys = client.list("tls/", "tls/~").await.unwrap();
+    assert_eq!(keys.len(), 10);
+    client.delete("tls/key-0").await.unwrap();
+
+    // A client that does not trust the test CA must fail certificate
+    // verification (the system roots do not include it).
+    let untrusted = OxiaClientBuilder::new()
+        .service_address(cluster.address.clone())
+        .request_timeout(Duration::from_secs(3))
+        .tls(TlsOptions::new())
+        .build()
+        .await;
+    assert!(
+        untrusted.is_err(),
+        "a client without the cluster CA must be rejected"
+    );
+
+    client.close().await.unwrap();
+}
+
+/// Mutual TLS: the server requires a client certificate; a client presenting
+/// one works end to end, a client without one is rejected.
+#[tokio::test]
+async fn test_tls_mutual_auth() {
+    let certs = generate_certs();
+    let cluster = start_tls_oxia(&certs, true).await;
+
+    let tls = TlsOptions::new()
+        .trusted_ca_pem(certs.ca_pem.clone())
+        .identity_pem(certs.client_cert_pem.clone(), certs.client_key_pem.clone());
+    let client = connect_with_retry(&cluster.address, tls).await;
+
+    client.put("mtls/key", b"secret".to_vec()).await.unwrap();
+    let got = client.get("mtls/key").await.unwrap();
+    assert_eq!(got.value.as_deref(), Some(b"secret".as_ref()));
+
+    // Without a client certificate the handshake must be rejected.
+    let no_identity = OxiaClientBuilder::new()
+        .service_address(cluster.address.clone())
+        .request_timeout(Duration::from_secs(3))
+        .tls(TlsOptions::new().trusted_ca_pem(certs.ca_pem.clone()))
+        .build()
+        .await;
+    assert!(
+        no_identity.is_err(),
+        "a client without a certificate must be rejected by mutual TLS"
+    );
+
+    client.close().await.unwrap();
+}


### PR DESCRIPTION
## What

Adds TLS support behind a new **off-by-default `tls` Cargo feature** (rustls via tonic, ring crypto provider — no cmake/aws-lc build dependency for consumers), resolving roadmap item **P3-1** and the TLS half of the P3-G gate. The surface mirrors the Go client:

- **`https://` service address** (or Go's **`tls://`** alias) → TLS with default options, verifying the server against the **operating system's trust roots** (same default as Go).
- **`OxiaClientBuilder::tls(TlsOptions)`** → custom **trusted CA** (PEM), client certificate for **mutual TLS**, and a **domain-name override** (SNI / certificate-name verification).

```rust
let client = OxiaClient::builder()
    .service_address("https://oxia.example.com:6648")
    .tls(TlsOptions::new().trusted_ca_pem(ca_pem))
    .build()
    .await?;
```

## Design notes

- All connections flow through the provider manager — the single dial choke point — which applies the TLS config and rewrites the **scheme-less shard-assignment addresses** from `http://` to `https://`, so the shard leaders the client re-dials are also reached over TLS.
- `TlsOptions` holds plain PEM data (no tonic types), so the builder/options stay `Debug`, `Clone`, and unwind-safe (the compile-time unwind-safety guard from #52 now also covers this config). Its `Debug` impl redacts certificate/key material.
- Without the feature, an `https://` address fails fast in `build()` with an actionable message instead of a deep transport error.

## End-to-end tests (real TLS cluster)

`oxia standalone` cannot serve TLS, so the new `tls_tests.rs` runs a **minimal real cluster in one container**: an `oxia server` (dataserver) with TLS on its public port + an `oxia coordinator` (`--conf` cluster config; internal traffic stays plaintext). Certificates come from a **per-test throwaway CA** (rcgen, dev-dependency); the cluster config advertises the host-mapped port so the assignment addresses the client re-dials are reachable and covered by the server certificate's `localhost` SAN.

- `test_tls_end_to_end` — custom-CA handshake; puts/gets/list/delete across **2 shards** (proving the assignment-address `https` rewrite); a client without the CA is **rejected**.
- `test_tls_mutual_auth` — server requires client certificates; a client presenting an identity round-trips; one without is **rejected**.

Both pass locally in ~15s total.

## CI

- Feature clippy step widened to `--all-features` (covers `otel` + `tls` together).
- New step runs the TLS e2e tests with `--features tls`.

## Verification

- `cargo fmt --check` · clippy workspace default **and** `--all-features`, `-D warnings`
- unit: 51 default / 52 all-features · doctests 13 all-features
- `RUSTDOCFLAGS="-D warnings" cargo doc --all-features`
- TLS e2e (2 tests, real containers) · default plaintext IT spot-check
