### PR TITLE
docs: examples for TLS, auth, streaming scans, shutdown, and retries

### DIFF
--- a/oxia-client/Cargo.toml
+++ b/oxia-client/Cargo.toml
@@ -46,6 +46,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }
+# The `signal` feature is for the graceful_shutdown example's Ctrl-C handling.
+tokio = { workspace = true, features = ["signal"] }
 jsonwebtoken = "9"
 serde = { version = "1", features = ["derive"] }
 opentelemetry_sdk = { workspace = true, features = ["metrics", "testing", "rt-tokio"] }
@@ -57,3 +59,7 @@ tokio-test = "0.4"
 [build-dependencies]
 tonic-build = { workspace = true }
 protox = { workspace = true }
+
+[[example]]
+name = "security_tls"
+required-features = ["tls"]

--- a/oxia-client/examples/README.md
+++ b/oxia-client/examples/README.md
@@ -1,0 +1,23 @@
+# Examples
+
+Every example runs against a local Oxia at `localhost:6648` (unless noted):
+
+```shell
+docker run -p 6648:6648 oxia/oxia:main oxia standalone
+cargo run --example basic_kv
+```
+
+| Example | Shows |
+|---|---|
+| [basic_kv](basic_kv.rs) | Put, get, list, range-scan, delete, delete-range |
+| [basic_versioning](basic_versioning.rs) | Versions and conditional writes (compare-and-swap) |
+| [basic_complex_query](basic_complex_query.rs) | Floor / ceiling / lower / higher gets |
+| [basic_secondary](basic_secondary.rs) | Secondary indexes |
+| [metadata_ephemeral](metadata_ephemeral.rs) | Ephemeral records and sessions |
+| [metadata_notification](metadata_notification.rs) | The namespace change feed |
+| [streaming_sequence](streaming_sequence.rs) | Sequential keys and sequence updates |
+| [streaming_scan](streaming_scan.rs) | Streaming list / range-scan in O(shards) memory |
+| [retry_patterns](retry_patterns.rs) | Application-level retries: `is_retryable`, CAS loops, semantic outcomes |
+| [graceful_shutdown](graceful_shutdown.rs) | Stop producers → drain in-flight ops → `close()` |
+| [security_auth](security_auth.rs) | Bearer-token authentication (static + rotating provider) |
+| [security_tls](security_tls.rs) | TLS: system roots, custom CA, mutual TLS — `cargo run --features tls --example security_tls` |

--- a/oxia-client/examples/graceful_shutdown.rs
+++ b/oxia-client/examples/graceful_shutdown.rs
@@ -1,0 +1,75 @@
+//! Graceful shutdown: stop producing, drain in-flight operations, then close.
+//!
+//! `close()` flushes operations already submitted to batches before tearing
+//! the client down, and ephemeral records are removed with the session. The
+//! application's job is the ordering: (1) stop issuing new operations,
+//! (2) wait for in-flight ones, (3) `close()`. Operations still racing a
+//! closed client fail with `OxiaError::Closed` — treat that as shutdown, not
+//! as an error.
+//!
+//! Runs until Ctrl-C (or stops by itself after 10 seconds).
+
+use oxia::{OxiaClient, OxiaError};
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+use tracing::level_filters::LevelFilter;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .with_target(false)
+        .init();
+
+    let client = OxiaClient::connect("localhost:6648").await.unwrap();
+    let shutdown = CancellationToken::new();
+
+    // A few producers writing continuously. Each checks the shutdown signal
+    // between operations and treats `Closed` as a normal way to stop.
+    let mut producers = tokio::task::JoinSet::new();
+    for worker in 0..4 {
+        let client = client.clone();
+        let shutdown = shutdown.clone();
+        producers.spawn(async move {
+            let mut written = 0u64;
+            while !shutdown.is_cancelled() {
+                let key = format!("shutdown/w{worker}/{written}");
+                match client.put(key, "payload").await {
+                    Ok(_) => written += 1,
+                    // The client was closed while this op was in flight:
+                    // shutdown has begun, just stop.
+                    Err(OxiaError::Closed) => break,
+                    Err(e) => panic!("write failed: {e}"),
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            written
+        });
+    }
+    info!("Producers running — Ctrl-C to shut down");
+
+    // Wait for Ctrl-C (or a timer, so the example ends on its own).
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => info!("Ctrl-C received"),
+        _ = tokio::time::sleep(Duration::from_secs(10)) => info!("Demo timer elapsed"),
+    }
+
+    // 1. Stop issuing new operations.
+    shutdown.cancel();
+
+    // 2. Let every in-flight operation finish.
+    let mut total = 0u64;
+    while let Some(written) = producers.join_next().await {
+        total += written.unwrap();
+    }
+    info!("Producers drained: {total} writes completed");
+
+    // 3. Close: flushes anything still batched, then releases the session.
+    client.close().await.unwrap();
+    info!("Client closed cleanly");
+}

--- a/oxia-client/examples/retry_patterns.rs
+++ b/oxia-client/examples/retry_patterns.rs
@@ -1,0 +1,120 @@
+//! Application-level retry patterns.
+//!
+//! The client already retries transient failures internally — re-routing via
+//! leader hints, re-hashing across shard splits, with backoff, bounded by the
+//! request timeout — so every error you observe is post-retry. What remains
+//! is application judgment:
+//!
+//! 1. Semantic outcomes (`KeyNotFound`, `UnexpectedVersionId`) are domain
+//!    results to match on, not failures to retry.
+//! 2. Errors with `is_retryable() == true` are safe to retry unconditionally
+//!    for idempotent operations (gets, version-conditioned writes).
+//! 3. An *unconditional* put that failed may still have been applied by the
+//!    server (at-least-once under retries) — make writes idempotent with a
+//!    version condition to get exactly-once, then retry freely.
+
+use oxia::{OxiaClient, OxiaError, PutResult};
+use std::time::Duration;
+use tracing::level_filters::LevelFilter;
+use tracing::{info, warn};
+
+/// Retries a fallible operation on retryable errors, with exponential
+/// backoff, up to `max_attempts`. Request builders implement `IntoFuture`,
+/// so `op` can return one directly.
+async fn with_retries<T, Fut>(
+    max_attempts: u32,
+    mut op: impl FnMut() -> Fut,
+) -> Result<T, OxiaError>
+where
+    Fut: IntoFuture<Output = Result<T, OxiaError>>,
+{
+    let mut backoff = Duration::from_millis(100);
+    let mut attempt = 1;
+    loop {
+        match op().await {
+            Ok(value) => return Ok(value),
+            Err(e) if e.is_retryable() && attempt < max_attempts => {
+                warn!("attempt {attempt} failed ({e}), retrying in {backoff:?}");
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(Duration::from_secs(5));
+                attempt += 1;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+/// Compare-and-swap loop: re-read and re-apply on version conflicts.
+/// Version-conditioned writes are exactly-once, so losing a race is the only
+/// way this fails — just refresh and try again.
+async fn increment_counter(client: &OxiaClient, key: &str) -> Result<PutResult, OxiaError> {
+    loop {
+        let (current, version_id) = match client.get(key).await {
+            Ok(record) => {
+                let n: u64 = String::from_utf8_lossy(record.value.as_deref().unwrap_or(b"0"))
+                    .parse()
+                    .unwrap_or(0);
+                (n, Some(record.version.version_id))
+            }
+            // Semantic outcome, not a failure: the counter just doesn't exist yet.
+            Err(OxiaError::KeyNotFound) => (0, None),
+            Err(e) => return Err(e),
+        };
+
+        let put = client.put(key, (current + 1).to_string());
+        let result = match version_id {
+            Some(v) => put.expected_version_id(v).await,
+            None => put.expected_record_not_exists().await,
+        };
+        match result {
+            Ok(r) => return Ok(r),
+            // Someone else won the race: refresh and retry.
+            Err(OxiaError::UnexpectedVersionId) => {
+                info!("version conflict on {key}, retrying");
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .with_target(false)
+        .init();
+
+    let client = OxiaClient::connect("localhost:6648").await.unwrap();
+
+    // Pattern 1: KeyNotFound is a result, not an error to retry.
+    match client.get("retry/missing").await {
+        Ok(record) => info!("found {:?}", record.key),
+        Err(OxiaError::KeyNotFound) => info!("retry/missing does not exist (expected)"),
+        Err(e) => panic!("lookup failed: {e}"),
+    }
+
+    // Pattern 2: retry retryable errors for idempotent operations.
+    let record = with_retries(5, || client.get("retry/config")).await;
+    info!("bounded-retry get returned: {record:?}");
+
+    // Pattern 3: exactly-once increments via CAS, racing three tasks.
+    client.delete("retry/counter").await.ok();
+    let mut tasks = tokio::task::JoinSet::new();
+    for _ in 0..3 {
+        let client = client.clone();
+        tasks.spawn(async move { increment_counter(&client, "retry/counter").await.unwrap() });
+    }
+    while tasks.join_next().await.is_some() {}
+    let counter = client.get("retry/counter").await.unwrap();
+    info!(
+        "counter after 3 concurrent CAS increments: {:?}",
+        counter.value.as_ref().map(|v| String::from_utf8_lossy(v))
+    );
+
+    client.close().await.unwrap();
+}

--- a/oxia-client/examples/security_auth.rs
+++ b/oxia-client/examples/security_auth.rs
@@ -1,0 +1,70 @@
+//! Bearer-token authentication.
+//!
+//! Every request carries an `authorization: Bearer <token>` header. Two ways
+//! to supply the token:
+//! - [`auth_token`](oxia::OxiaClientBuilder::auth_token): a static token.
+//! - [`auth_token_provider`](oxia::OxiaClientBuilder::auth_token_provider): a
+//!   closure called once per request, so rotated credentials are picked up
+//!   transparently. It must return quickly and never block — refresh tokens
+//!   elsewhere (e.g. a background task) and hand out the cached value here.
+//!
+//! Environment:
+//! - `OXIA_ADDRESS` — service address (default: `localhost:6648`)
+//! - `OXIA_TOKEN`   — the bearer token to present
+//!
+//! Tokens are readable by anyone who can observe the connection; combine
+//! authentication with TLS (see the `security_tls` example) outside trusted
+//! networks.
+
+use oxia::OxiaClient;
+use std::sync::{Arc, RwLock};
+use tracing::info;
+use tracing::level_filters::LevelFilter;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .with_target(false)
+        .init();
+
+    let address = std::env::var("OXIA_ADDRESS").unwrap_or_else(|_| "localhost:6648".to_string());
+    let token = std::env::var("OXIA_TOKEN").unwrap_or_default();
+
+    // Simplest form: a static token.
+    let client = OxiaClient::builder()
+        .service_address(address.clone())
+        .auth_token(token.clone())
+        .build()
+        .await
+        .unwrap();
+    info!("Connected with a static token");
+    client.put("auth/static", "hello").await.unwrap();
+    client.close().await.unwrap();
+
+    // Rotating credentials: the provider is consulted for every request.
+    // Here a shared slot stands in for whatever refreshes the token (an OAuth
+    // client, a file watcher, ...) — the closure itself just reads the cache.
+    let current_token = Arc::new(RwLock::new(token));
+    let provider_view = current_token.clone();
+    let client = OxiaClient::builder()
+        .service_address(address)
+        .auth_token_provider(move || provider_view.read().expect("token lock").clone())
+        .build()
+        .await
+        .unwrap();
+    info!("Connected with a token provider");
+
+    client.put("auth/rotating", "hello").await.unwrap();
+    // A refresher updating the slot is picked up by the very next request:
+    *current_token.write().expect("token lock") = "refreshed-token".to_string();
+
+    let record = client.get("auth/rotating").await;
+    info!("Read after rotation: {record:?}");
+
+    client.close().await.unwrap();
+}

--- a/oxia-client/examples/security_tls.rs
+++ b/oxia-client/examples/security_tls.rs
@@ -1,0 +1,75 @@
+//! Connecting over TLS (requires the `tls` Cargo feature):
+//!
+//! ```shell
+//! cargo run --features tls --example security_tls
+//! ```
+//!
+//! Environment:
+//! - `OXIA_ADDRESS`     — service address (default: `https://localhost:6648`;
+//!   an `https://` or `tls://` address enables TLS with the system trust roots)
+//! - `OXIA_CA_CERT`     — path to a PEM CA certificate to trust instead of the
+//!   system roots (e.g. a self-signed cluster CA)
+//! - `OXIA_CLIENT_CERT` / `OXIA_CLIENT_KEY` — paths to a PEM client
+//!   certificate and key, for clusters requiring mutual TLS
+
+use oxia::{OxiaClient, TlsOptions};
+use tracing::info;
+use tracing::level_filters::LevelFilter;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .with_target(false)
+        .init();
+
+    let address =
+        std::env::var("OXIA_ADDRESS").unwrap_or_else(|_| "https://localhost:6648".to_string());
+
+    // Default: verify the server against the operating system's trust roots.
+    let mut tls = TlsOptions::new();
+
+    // Custom CA: trust the cluster's CA instead of the system roots.
+    if let Ok(ca_path) = std::env::var("OXIA_CA_CERT") {
+        let ca_pem = std::fs::read(&ca_path).expect("read CA certificate");
+        tls = tls.trusted_ca_pem(ca_pem);
+        info!("Trusting CA from {ca_path}");
+    }
+
+    // Mutual TLS: present a client certificate.
+    if let (Ok(cert_path), Ok(key_path)) = (
+        std::env::var("OXIA_CLIENT_CERT"),
+        std::env::var("OXIA_CLIENT_KEY"),
+    ) {
+        let cert_pem = std::fs::read(&cert_path).expect("read client certificate");
+        let key_pem = std::fs::read(&key_path).expect("read client key");
+        tls = tls.identity_pem(cert_pem, key_pem);
+        info!("Presenting client identity from {cert_path}");
+    }
+
+    let client = OxiaClient::builder()
+        .service_address(address.clone())
+        .tls(tls)
+        .build()
+        .await
+        .unwrap();
+    info!("Connected over TLS to {address}");
+
+    let put_result = client
+        .put("tls/hello", "encrypted in transit")
+        .await
+        .unwrap();
+    info!("Put succeeded, version {:?}", put_result.version.version_id);
+    let record = client.get("tls/hello").await.unwrap();
+    info!(
+        "Got {:?} = {:?}",
+        record.key,
+        record.value.as_ref().map(|v| String::from_utf8_lossy(v))
+    );
+
+    client.close().await.unwrap();
+}

--- a/oxia-client/examples/streaming_scan.rs
+++ b/oxia-client/examples/streaming_scan.rs
@@ -1,0 +1,62 @@
+//! Streaming list and range-scan: iterate a key range of any size in
+//! O(shards) memory.
+//!
+//! `list(..)` / `range_scan(..)` awaited directly collect the whole result
+//! into a `Vec` — fine for bounded ranges. Chaining `.stream()` instead
+//! returns an ordered async stream that pulls from the server only as fast as
+//! it is consumed (buffering at most one pending item per shard), so a scan
+//! over millions of records runs in constant memory. Items arrive in Oxia's
+//! global slash-aware key order; the first error terminates the stream.
+
+use futures::StreamExt;
+use oxia::OxiaClient;
+use tracing::info;
+use tracing::level_filters::LevelFilter;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .with_target(false)
+        .init();
+
+    let client = OxiaClient::connect("localhost:6648").await.unwrap();
+
+    // Seed some records.
+    for i in 0..500 {
+        client
+            .put(format!("scan/item-{i:04}"), format!("value-{i}"))
+            .await
+            .unwrap();
+    }
+    info!("Seeded 500 records");
+
+    // Stream just the keys, in order, without materializing the whole range.
+    let mut keys = client.list("scan/", "scan/~").stream().await.unwrap();
+    let mut count = 0;
+    while let Some(key) = keys.next().await {
+        let key = key.unwrap();
+        if count < 3 {
+            info!("key: {key}");
+        }
+        count += 1;
+    }
+    info!("Streamed {count} keys");
+
+    // Stream full records (keys and values). Dropping the stream early
+    // cancels the underlying RPCs, so consuming only a prefix is cheap.
+    let mut records = client.range_scan("scan/", "scan/~").stream().await.unwrap();
+    let mut bytes: usize = 0;
+    while let Some(record) = records.next().await {
+        let record = record.unwrap();
+        bytes += record.value.as_ref().map(|v| v.len()).unwrap_or(0);
+    }
+    info!("Streamed all records: {bytes} value bytes total");
+
+    client.delete_range("scan/", "scan/~").await.unwrap();
+    client.close().await.unwrap();
+}


### PR DESCRIPTION
## What

Adds the five examples that were waiting on Phase 3 (**P5-5**, the last open Phase 5 item), plus an `examples/README.md` index of the full set:

| Example | Shows |
|---|---|
| `security_tls` | TLS via `https://` + system roots, custom CA, mutual TLS — env-driven; `cargo run --features tls --example security_tls` |
| `security_auth` | Static bearer token + a rotating `TokenProvider` backed by a shared slot a refresher updates |
| `streaming_scan` | Ordered streaming list / range-scan in O(shards) memory via `.stream()`, vs collect-all |
| `graceful_shutdown` | The shutdown ordering: stop producers → drain in-flight ops → `close()`; `OxiaError::Closed` treated as shutdown, not an error |
| `retry_patterns` | App-level judgment over the client's internal retries: semantic outcomes matched not retried, bounded-backoff helper over `is_retryable()` (builders plug in via `IntoFuture`), exactly-once CAS increment loop raced by 3 tasks |

## Notes

- `security_tls` is gated with `[[example]] required-features = ["tls"]`, so default builds skip it; the existing `--all-features` clippy CI step lints it.
- The `signal` tokio feature is added to **dev-dependencies** only, for the Ctrl-C handling.
- No CI changes needed: `cargo test --workspace` already compiles example targets, and clippy `--all-targets` lints them.

## Verification

All five smoke-tested against real servers:
- plaintext examples against `oxia standalone` — `retry_patterns` logs real CAS conflicts and lands the counter at exactly 3; `graceful_shutdown` drained 724 in-flight writes and closed cleanly
- `security_tls` against the one-container TLS cluster (custom CA handshake, put/get round-trip)

Plus: `cargo fmt --check`, workspace clippy `-D warnings` (default and `--all-features`), examples built in both feature configs.